### PR TITLE
changes all skillpoint values to 4

### DIFF
--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -798,10 +798,8 @@
 
 /decl/species/proc/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
 	switch(age)
-		if(0 to 22) 	. = -4
-		if(23 to 30) 	. = 0
-		if(31 to 45)	. = 4
-		else			. = 8
+		if(0 to 100) 	. = 4
+		else			. = 4
 
 /decl/species/proc/post_organ_rejuvenate(var/obj/item/organ/org, var/mob/living/carbon/human/H)
 	if(org && (org.species ? org.species.is_crystalline : is_crystalline))


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Standard humans and all races without overrides (e.g. everything but vox and GAS as of now and those are lol) start with +4 skillpoints instead of a varying range between -4 and 8. This isn't a modpack but I have permission and this is specifically after I asked nebula if they were interested in a similar change upstream and a maintainer expressed no interest in changing it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
-young characters no longer have to choose between doing their job and taking rp skills like botany and law
-heads of staff have a less extreme advantage in skills over subordinates that promotes doing their job
-aliens no longer have an unfair advantage over their younger coworkers in departments where it really matters (like security)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Rock
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl: Rock
tweak: age no longer affects skillpoints.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
