### PR TITLE
Removes the Nuke

### DIFF
--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -1613,9 +1613,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/landmark{
-	name = "Nuclear-Bomb"
-	},
 /obj/structure/railing/mapped{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Removes the nuke from the Merc Base

## Why and what will this PR improve

The portable nuke isn't a great gameplay mechanic, especially considering it doesn't have a ton of interactivity beyond get codes, set bomb, blow. There's still an option to destroy the ship via the self destruct.

## Authorship

Me

## Changelog

:cl: Deadmon
rscdel: Removes the nuke from the merc base/ship.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
