### PR TITLE
Fixes charge pylon shocking adherent

### DIFF
--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -38,10 +38,11 @@
 		user.apply_damage(150, BURN, def_zone = BP_CHEST)
 		visible_message("<span class='danger'>Electricity arcs off [user] as it touches \the [src]!</span>")
 		to_chat(user, "<span class='danger'><b>You detect damage to your components!</b></span>")
+		user.throw_at(get_step(user,get_dir(src,user)), 5, 10)
 	else
 		user.electrocute_act(100, src, def_zone = BP_CHEST)
 		visible_message("<span class='danger'>\The [user] has been shocked by \the [src]!</span>")
-	user.throw_at(get_step(user,get_dir(src,user)), 5, 10)
+		user.throw_at(get_step(user,get_dir(src,user)), 5, 10)
 
 /obj/structure/charge_pylon/attackby(var/obj/item/grab/G, mob/user)
 	if(!istype(G))

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -34,7 +34,7 @@
 	if(power_cell)
 		power_cell.charge = power_cell.maxcharge
 		to_chat(user, "<span class='notice'><b>Your [power_cell] has been charged to capacity.</b></span>")
-	if(isrobot(user))
+	else if(isrobot(user))
 		user.apply_damage(150, BURN, def_zone = BP_CHEST)
 		visible_message("<span class='danger'>Electricity arcs off [user] as it touches \the [src]!</span>")
 		to_chat(user, "<span class='danger'><b>You detect damage to your components!</b></span>")


### PR DESCRIPTION


## Description of changes

Title. Fixes charge pylon (electron resevoir) shocking adherent, as this is unintended.



## Changelog

:cl:
bugfix: adherent pylon no longer fries adherent
/:cl:
