### PR TITLE
O2 Locker Guaranteed Softsuit

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -20,15 +20,17 @@
 	closet_appearance = /decl/closet_appearance/oxygen
 
 /obj/structure/closet/emcloset/WillContain()
-	//Guaranteed kit - two tanks and masks
-	. = list(/obj/item/tank/emergency/oxygen = 2,
-			/obj/item/clothing/mask/breath = 2)
+	//Guaranteed kit - two tanks, two masks, two O2 pouches, and a softsuit
+	. = list(/obj/item/tank/emergency/oxygen/engi = 2,
+			/obj/item/clothing/mask/breath = 2,
+			/obj/item/storage/med_pouch/oxyloss = 2,
+			/obj/item/clothing/suit/space/emergency,
+			/obj/item/clothing/head/helmet/space/emergency)
 
 	. += new/datum/atom_creator/simple(list(/obj/item/storage/toolbox/emergency, /obj/item/inflatable/wall = 2), 75)
-	. += new/datum/atom_creator/simple(list(/obj/item/tank/emergency/oxygen/engi, /obj/item/clothing/mask/gas/half), 10)
-	. += new/datum/atom_creator/simple(/obj/item/oxycandle, 15)
-	. += new/datum/atom_creator/simple(/obj/item/storage/firstaid/o2, 25)
-	. += new/datum/atom_creator/simple(list(/obj/item/clothing/suit/space/emergency,/obj/item/clothing/head/helmet/space/emergency), 25)
+	. += new/datum/atom_creator/simple(list(/obj/item/clothing/mask/gas/half, /obj/item/tank/oxygen), 10)
+	. += new/datum/atom_creator/simple(/obj/item/oxycandle, 75)
+	. += new/datum/atom_creator/simple(/obj/item/storage/firstaid/regular, 25)
 
 /*
  * Fire Closet


### PR DESCRIPTION
Makes it so that softsuits are a guaranteed spawn in O2 lockers instead of a 25% chance of spawning 2, also adds two O2 pouches to guaranteed spawn. 

This way, searching O2 lockers in an emergency isn't a gamble, as it is with most rounds when there's a breach.
![image](https://user-images.githubusercontent.com/43841046/138572238-05692de0-98c8-40b7-81c4-38452dafe6e7.png)
