### PR TITLE
Loadout Tweaks

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -1,6 +1,6 @@
 /decl/loadout_category/eyes
 	name = "Eyewear"
-	
+
 /decl/loadout_option/eyes
 	category = /decl/loadout_category/eyes
 	slot = slot_glasses_str
@@ -40,3 +40,67 @@
 	name = "blindfold"
 	path = /obj/item/clothing/glasses/blindfold
 	flags = GEAR_HAS_COLOR_SELECTION
+
+/decl/loadout_option/eyes/medical
+	name = "medical eyewear selection"
+	path = /obj/item/clothing/glasses/hud/health
+
+/decl/loadout_option/eyes/medical/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"health scanner HuD" = /obj/item/clothing/glasses/hud/health,
+		"health scanner HuD, prescription" = /obj/item/clothing/glasses/hud/health/prescription,
+		"health scanner HuD, visor" = /obj/item/clothing/glasses/hud/health/visor,
+		"health scanner eyepatch" = /obj/item/clothing/glasses/eyepatch/hud/medical
+	)
+
+/decl/loadout_option/eyes/security
+	name = "security eyewear selection"
+	path = /obj/item/clothing/glasses/hud/security
+
+/decl/loadout_option/eyes/security/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"security HuD" = /obj/item/clothing/glasses/hud/security,
+		"security HuD, prescription" = /obj/item/clothing/glasses/hud/security/prescription,
+		"security sunglasses" = /obj/item/clothing/glasses/sunglasses/sechud,
+		"security aviators" = /obj/item/clothing/glasses/sunglasses/sechud/toggle,
+		"security eyepatch" = /obj/item/clothing/glasses/eyepatch/hud/security
+	)
+
+/decl/loadout_option/eyes/meson
+	name = "meson eyewear selection"
+	path = /obj/item/clothing/glasses/meson
+
+
+/decl/loadout_option/eyes/meson/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"meson goggles" = /obj/item/clothing/glasses/meson,
+		"meson goggles, prescription" = /obj/item/clothing/glasses/meson/prescription,
+		"meson eyepatch" = /obj/item/clothing/glasses/eyepatch/hud/meson
+	)
+
+/decl/loadout_option/eyes/sciencegoggles
+	name = "scientific eyewear selection"
+	path = /obj/item/clothing/glasses/science
+
+/decl/loadout_option/eyes/sciencegoggles/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"science goggles" = /obj/item/clothing/glasses/science,
+		"science goggles, prescription" = /obj/item/clothing/glasses/science/prescription,
+		"science eyepatch" = /obj/item/clothing/glasses/eyepatch/hud/science
+	)
+
+/decl/loadout_option/eyes/welding
+	name = "welding goggles"
+	path = /obj/item/clothing/glasses/welding
+
+/decl/loadout_option/eyes/material
+	name = "optical material scanner"
+	path = /obj/item/clothing/glasses/material

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -73,3 +73,23 @@
 		"utility knife" =             /obj/item/knife/utility,
 		"lightweight utility knife" = /obj/item/knife/utility/lightweight
 	)
+
+/decl/loadout_option/utility/cheaptablet
+	name = "tablet computer, cheap"
+	path = /obj/item/modular_computer/tablet/preset/custom_loadout/cheap
+	cost = 3
+
+/decl/loadout_option/utility/normaltablet
+	name = "tablet computer, advanced"
+	path = /obj/item/modular_computer/tablet/preset/custom_loadout/advanced
+	cost = 4
+
+/decl/loadout_option/utility/cheaplaptop
+	name = "laptop computer, cheap"
+	path = /obj/item/modular_computer/laptop/preset/custom_loadout/cheap
+	cost = 3
+
+/decl/loadout_option/utility/normallaptop
+	name = "laptop computer, advanced"
+	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced
+	cost = 4

--- a/maps/torch/loadout/loadout_tactical.dm
+++ b/maps/torch/loadout/loadout_tactical.dm
@@ -5,7 +5,7 @@
 	name = "Tactical"
 
 /decl/loadout_option/tactical
-	category = /decl/loadout_category/accessories
+	category = /decl/loadout_category/tactical
 	slot = slot_tie_str
 
 /decl/loadout_option/tactical/holster
@@ -113,3 +113,14 @@
 	pouches["green large armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/green
 	pouches["tan large armor pouches"] = /obj/item/clothing/accessory/storage/pouches/large/tan
 	gear_tweaks += new/datum/gear_tweak/path(pouches)
+
+/decl/loadout_option/tactical/knife_sheath
+	name = "knife sheath selection"
+	path = /obj/item/clothing/accessory/storage/holster/knife
+
+/decl/loadout_option/tactical/knife_sheath/Initialize()
+	. = ..()
+	var/sheaths = list()
+	sheaths["leather knife sheath"] = /obj/item/clothing/accessory/storage/holster/knife
+	sheaths["polymer knife sheath"] = /obj/item/clothing/accessory/storage/holster/knife/polymer
+	gear_tweaks += new/datum/gear_tweak/path(sheaths)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Added eyewear selection for every job in the Eyewear Tab.
Moved a bunch of tactical stuff from the Accessories to the Tactical Tab.
Added Knife Sheaths to the Tactical Tab.
Added Computers to the Utility Tab.

## Why and what will this PR improve
Now people who need prescription eyewear don't have to choose between getting a HuD and not bonking against every wall.
Also, people will be able to get have a tablet or laptop without having to buy it every single round.

## Authorship

Me.
## Changelog

:cl:
rscadd:Added Job-Related eyewear selections to the loadout, including prescriptions.
rscadd:Added Tablets and Laptops to the Utility Tab in the Loadout Menu.
rscadd:Added Knife Sheaths to the Loadout.
fix:Moved Tactical stuff to the Tactical Tab in the loadout.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
