### PR TITLE
Adds a Storage Accessories Category to Loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -149,17 +149,6 @@
 		"cross, gold" =   /obj/item/cross/gold
 	)
 
-/decl/loadout_option/wallet
-	name = "wallet, colour select"
-	path = /obj/item/storage/wallet
-	flags = GEAR_HAS_COLOR_SELECTION
-
-/decl/loadout_option/wallet_poly
-	name = "wallet, polychromic"
-	path = /obj/item/storage/wallet/poly
-	cost = 2
-
-
 /decl/loadout_option/swiss
 	name = "multi-tool"
 	path = /obj/item/knife/folding/swiss

--- a/code/modules/client/preference_setup/loadout/lists/storage.dm
+++ b/code/modules/client/preference_setup/loadout/lists/storage.dm
@@ -1,0 +1,64 @@
+/decl/loadout_category/storage
+	name = "Storage Accessories"
+
+/decl/loadout_option/storage
+	category = /decl/loadout_category/storage
+	slot = slot_tie_str
+
+/decl/loadout_option/storage/vest
+	name = "webbing vest selection"
+	path = /obj/item/clothing/accessory/storage/vest
+	cost = 3
+
+/decl/loadout_option/storage/vest/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"black webbing vest" =           /obj/item/clothing/accessory/storage/vest/black,
+		"brown webbing vest" =            /obj/item/clothing/accessory/storage/vest/brown,
+		"white webbing vest" = /obj/item/clothing/accessory/storage/vest/white
+	)
+
+/decl/loadout_option/storage/pouches
+	name = "drop pouches selection"
+	path = /obj/item/clothing/accessory/storage/drop_pouches
+	cost = 3
+
+/decl/loadout_option/storage/pouches/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"black drop pouches" =           /obj/item/clothing/accessory/storage/drop_pouches/black,
+		"brown drop pouches" =            /obj/item/clothing/accessory/storage/drop_pouches/brown,
+		"white drop pouches" = /obj/item/clothing/accessory/storage/drop_pouches/white
+	)
+
+/decl/loadout_option/storage/belts
+	name = "storage belt selection"
+	path = /obj/item/storage/belt
+	slot = slot_belt_str
+	cost = 3
+
+/decl/loadout_option/storage/belts/get_gear_tweak_options()
+	. = ..()
+	LAZYINITLIST(.[/datum/gear_tweak/path])
+	.[/datum/gear_tweak/path] |= list(
+		"equipment belt" =           /obj/item/storage/belt/general,
+		"waist pack" =            /obj/item/storage/belt/waistpack,
+		"large waist pack" = /obj/item/storage/belt/waistpack/big
+	)
+
+/decl/loadout_option/storage/bandolier
+	name = "bandolier"
+	path = /obj/item/clothing/accessory/storage/bandolier
+	cost = 2
+
+/decl/loadout_option/storage/wallet
+	name = "wallet, colour select"
+	path = /obj/item/storage/wallet
+	flags = GEAR_HAS_COLOR_SELECTION
+
+/decl/loadout_option/storage/wallet_poly
+	name = "wallet, polychromic"
+	path = /obj/item/storage/wallet/poly
+	cost = 2

--- a/nebula.dme
+++ b/nebula.dme
@@ -1574,6 +1574,7 @@
 #include "code\modules\client\preference_setup\loadout\lists\gloves.dm"
 #include "code\modules\client\preference_setup\loadout\lists\headwear.dm"
 #include "code\modules\client\preference_setup\loadout\lists\misc.dm"
+#include "code\modules\client\preference_setup\loadout\lists\storage.dm"
 #include "code\modules\client\preference_setup\loadout\lists\suits.dm"
 #include "code\modules\client\preference_setup\loadout\lists\uniforms.dm"
 #include "code\modules\client\preference_setup\loadout\lists\utility.dm"


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Just what it says on the title.

## Why and what will this PR improve
Adds the option to get drop pouches or vests in different colours, un-bloats Misc a lil bit since wallets were moved there

## Authorship
Guess who.

## Changelog

:cl:
rscadd;Added a Storage Accessories category to loadout. If you're using a wallet, please go to it, since they've been moved there from misc.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
