### PR TITLE
Adds synthesizable plasticide

### DIFF
--- a/mods/content/baychems/reactions.dm
+++ b/mods/content/baychems/reactions.dm
@@ -58,3 +58,9 @@
 	result = /decl/material/liquid/antidepressants/paroxetine
 	required_reagents = list(/decl/material/liquid/hallucinogenics = 1, /decl/material/liquid/acetone = 1, /decl/material/liquid/stabilizer = 1)
 	result_amount = 3
+
+/decl/chemical_reaction/plasticide
+	name = "Plasticide"
+	result = /decl/material/liquid/plasticide
+	required_reagents = list(/decl/material/solid/silicon = 2, /decl/material/liquid/mercury = 1, /decl/material/solid/sulfur = 1)
+	result_amount = 2


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

You can now make plasticide from chemicals found in the chemical dispenser.

## Why and what will this PR improve

There are many high-end recipes that require plasticide, such as synthmeat, nanite fluid, and so on.
Unfortunately, it is very annoying to be obtained by your standard chemist. This PR makes it so that plasticide can now be synthesized with the equipment found in the laboratory.

## Authorship

me

## Changelog

:cl:
tweak: Plasticide can now be made via a chemical reaction.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
