### PR TITLE
adds fuel to pacmans

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -9930,7 +9930,8 @@
 /area/quartermaster/expedition/eva)
 "Dr" = (
 /obj/machinery/power/port_gen/pacman{
-	anchored = 1
+	anchored = 1;
+	sheets = 25
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow,
@@ -11152,7 +11153,8 @@
 "Ko" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/port_gen/pacman{
-	anchored = 1
+	anchored = 1;
+	sheets = 10
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -24024,7 +24024,8 @@
 /area/security/brig)
 "tTS" = (
 /obj/machinery/power/port_gen/pacman{
-	anchored = 1
+	anchored = 1;
+	sheets = 25
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light/small{
@@ -25919,7 +25920,8 @@
 "ylp" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/power/port_gen/pacman{
-	anchored = 1
+	anchored = 1;
+	sheets = 25
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/emergency)


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Adds fuel to some of the pacmans, such as on the shuttles and in emergency storage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
It's funky for there to be so many pacmans without fuel.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Rock
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
tweak: most pacmans have a bit of fuel in them by default now.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
