### PR TITLE
Supply Remap

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -852,6 +852,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/cockpit)
+"co" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftport)
 "cp" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -2657,16 +2661,6 @@
 /obj/effect/paint_stripe/supply,
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/quartermaster/shuttlefuel)
-"gP" = (
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Warehouse Aft";
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/storage)
 "gT" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/quartermaster/hangar)
@@ -2806,12 +2800,6 @@
 "hq" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
-"ht" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/crate,
-/obj/random_multi/single_item/boombox,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "hu" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
@@ -2942,6 +2930,9 @@
 "hR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "hS" = (
@@ -2995,14 +2986,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"hZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "ia" = (
 /obj/effect/floor_decal/corner/purple/mono,
 /obj/structure/aicore/deactivated/research,
@@ -3176,44 +3159,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
 "iF" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/dispenser,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "iG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
-"iH" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "iI" = (
@@ -3398,6 +3348,10 @@
 	dir = 4;
 	level = 2
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "je" = (
@@ -3413,14 +3367,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
 "jf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/obj/structure/table{
-	name = "plastic table frame"
-	},
-/obj/machinery/cell_charger,
-/obj/random/powercell,
+/obj/structure/dispenser,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "jg" = (
@@ -3455,18 +3402,14 @@
 /area/quartermaster/storage)
 "jn" = (
 /obj/structure/rack{
-	dir = 8
+	dir = 4
 	},
-/obj/item/stack/material/cardstock/mapped/cardboard/fifty,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/item/tape_roll,
-/obj/machinery/light/small,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "jo" = (
@@ -3481,15 +3424,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
-"jp" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	dir = 1;
-	id_tag = "endeavour_dock";
-	pixel_y = -24;
-	tag_door = "endeavour_dock_door"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/storage)
 "jq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/floodlight,
@@ -4373,21 +4307,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/fore)
 "lo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Maintenance"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
 "lq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5332,11 +5262,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "nH" = (
@@ -5718,7 +5643,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "or" = (
@@ -5803,19 +5727,6 @@
 "oA" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/maintenance/fifthdeck/aftport)
-"oB" = (
-/obj/structure/rack{
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/electrical,
-/obj/item/storage/toolbox/emergency,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "oC" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -6214,17 +6125,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftport)
-"pC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "pF" = (
@@ -7439,8 +7339,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "sd" = (
@@ -7945,6 +7847,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
@@ -8001,11 +7906,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "tE" = (
@@ -8013,6 +7917,9 @@
 	dir = 9
 	},
 /obj/random/trash,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
@@ -8046,6 +7953,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
+"tT" = (
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/item/stack/material/cardstock/mapped/cardboard/fifty,
+/obj/item/tape_roll,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/storage)
 "tU" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -8929,6 +8848,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"xy" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/maintenance/fifthdeck/aftport)
 "xC" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced{
@@ -9386,12 +9322,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
-"zZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/prepainted,
-/area/maintenance/fifthdeck/aftport)
 "Am" = (
 /obj/effect/paint_stripe/command,
 /turf/simulated/wall/r_wall/prepainted,
@@ -9521,8 +9451,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod19/station)
 "Bk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -9979,6 +9915,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
+"DU" = (
+/obj/machinery/light/small,
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/storage)
 "DY" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -10252,6 +10193,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
+"Fq" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	dir = 1;
+	id_tag = "endeavour_dock";
+	pixel_y = -24;
+	tag_door = "endeavour_dock_door"
+	},
+/obj/structure/closet/crate/plastic,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/storage)
 "Fw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
@@ -10575,12 +10526,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
-"Hn" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small,
-/obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "Ho" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -10836,6 +10781,48 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
+"Iv" = (
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/item/tank/emergency/oxygen/engi,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/storage)
 "IH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11190,14 +11177,8 @@
 /turf/simulated/wall/r_titanium,
 /area/curiosity_hangar/start)
 "KU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/effect/paint_stripe/supply,
+/turf/simulated/wall/map_preset/tan,
 /area/maintenance/fifthdeck/aftport)
 "KW" = (
 /obj/structure/cable/cyan{
@@ -11435,6 +11416,12 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
+"Mn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/storage)
 "Mp" = (
 /obj/effect/paint/silver,
 /turf/simulated/wall/titanium,
@@ -11573,9 +11560,6 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = 32
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "MZ" = (
@@ -11683,6 +11667,27 @@
 /obj/effect/shuttle_landmark/escape_pod/start/pod18,
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod18/station)
+"Oe" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_construct,
+/obj/item/conveyor_switch_construct,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/storage)
 "Og" = (
 /turf/simulated/floor/tiled/dark,
 /area/bridge/ai/ai_upload)
@@ -11739,6 +11744,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "Oy" = (
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/machinery/cell_charger,
+/obj/random/powercell,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage)
@@ -12479,6 +12489,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod19/station)
+"Ui" = (
+/obj/machinery/camera/network/supply{
+	c_tag = "Supply Office - Warehouse Aft";
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/closet/crate/medical,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/storage)
 "Ul" = (
 /obj/effect/floor_decal/industrial/hatch/orange,
 /obj/structure/ship_munition/disperser_charge/fire,
@@ -12536,22 +12557,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/disperser)
-"UL" = (
-/obj/structure/rack{
-	dir = 4
-	},
-/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
-	amount = 30
-	},
-/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
-	amount = 30
-	},
-/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
-	amount = 30
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "UN" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4;
@@ -13016,6 +13021,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
+"XC" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftport)
 "XD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -13089,22 +13102,8 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/curiosity_hangar/start)
 "Yi" = (
-/obj/structure/rack{
-	dir = 4
-	},
-/obj/item/stack/material/sheet/mapped/steel/fifty{
-	amount = 30
-	},
-/obj/item/stack/material/sheet/mapped/steel/fifty{
-	amount = 30
-	},
-/obj/item/stack/material/sheet/mapped/steel/fifty{
-	amount = 30
-	},
-/obj/item/stack/material/reinforced/mapped/plasteel/ten{
-	amount = 20
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "Yj" = (
@@ -34272,11 +34271,11 @@ Em
 Em
 Em
 Em
-zZ
+Gu
 rj
 tC
 ws
-aa
+ws
 aa
 aa
 aa
@@ -34473,12 +34472,12 @@ if
 jd
 jf
 jn
-Em
+tT
 KU
 Bk
 tv
+co
 ws
-aa
 aa
 aa
 aa
@@ -34676,11 +34675,11 @@ je
 jg
 jg
 lo
+xy
 ts
-pC
 tD
+XC
 ws
-aa
 aa
 aa
 aa
@@ -34872,17 +34871,17 @@ iL
 MO
 ot
 gD
-hZ
 wi
+Iv
 AR
 Ym
 kZ
-Em
+Ym
+KU
 tt
-rz
 tE
+co
 ws
-aa
 aa
 aa
 aa
@@ -35075,16 +35074,16 @@ os
 OG
 ox
 iF
-Hn
+iF
 ss
 Ym
 Ym
-Em
+Ym
+KU
 uh
 wD
 Np
 ws
-aa
 aa
 aa
 aa
@@ -35277,16 +35276,16 @@ MW
 OG
 Oy
 Yi
-UL
+Yi
 ss
 Ym
 Ym
-Em
+Ym
+KU
 uh
 pt
 pu
 ws
-aa
 aa
 aa
 aa
@@ -35475,20 +35474,20 @@ zS
 sF
 zS
 HG
-MS
+Mn
 MS
 HG
 hR
 iG
 mD
 jl
-gP
-Em
+jl
+Ui
+KU
 uh
 pt
 zn
 ws
-aa
 aa
 aa
 aa
@@ -35680,17 +35679,17 @@ HG
 gq
 gq
 HG
-iH
-ht
+iF
+iF
 CL
 jm
 jm
-Em
+DU
+KU
 XT
 Ol
 pv
 ws
-aa
 aa
 aa
 aa
@@ -35882,17 +35881,17 @@ HG
 HG
 HG
 HG
-oB
 iJ
+Oe
 iZ
 jm
-jp
-Em
+jm
+Fq
+KU
 tw
 gI
 ws
 ws
-aa
 aa
 aa
 aa
@@ -36090,10 +36089,10 @@ Em
 Hq
 Hq
 Em
+KU
 ui
 ws
 ws
-aa
 aa
 aa
 aa
@@ -36292,9 +36291,9 @@ Ka
 Ij
 Ij
 cp
+aC
 Lm
 ws
-aa
 aa
 aa
 aa
@@ -36494,9 +36493,9 @@ ug
 zw
 Mc
 ug
+zr
 uj
 ws
-aa
 aa
 aa
 aa
@@ -36698,7 +36697,7 @@ Ha
 ws
 ws
 ws
-aa
+ws
 aa
 aa
 aa

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -31,7 +31,6 @@
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/maintenance/fourthdeck/forestarboard)
 "al" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -44,6 +43,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "am" = (
@@ -115,6 +118,7 @@
 	id_tag = "sup_office";
 	name = "Supply Desk Shutters"
 	},
+/obj/item/bell,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "ay" = (
@@ -447,6 +451,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
+"bK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "bM" = (
 /obj/effect/shuttle_landmark/merchant/out,
 /turf/space,
@@ -539,19 +560,7 @@
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
 "ce" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 8
-	},
-/obj/structure/hand_cart{
-	dir = 1
-	},
+/obj/effect/floor_decal/corner/brown,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
 "cf" = (
@@ -576,6 +585,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/janitor/storage)
+"cj" = (
+/obj/machinery/door/firedoor,
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/effect/paint_stripe/common,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar/top)
 "ck" = (
 /obj/structure/table,
 /obj/item/plunger,
@@ -1312,12 +1327,9 @@
 /obj/random/maintenance/solgov/clean,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
-"eQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/random/junk,
-/turf/simulated/floor/tiled/techfloor,
+"eU" = (
+/obj/effect/paint_stripe/supply,
+/turf/simulated/wall/map_preset/tan,
 /area/maintenance/fourthdeck/port)
 "eV" = (
 /obj/structure/closet/crate,
@@ -1361,7 +1373,7 @@
 "fa" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/nt_regs,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "fg" = (
 /obj/structure/cable/green{
@@ -1410,6 +1422,14 @@
 /obj/effect/paint_stripe/science,
 /turf/simulated/wall/map_preset/tan,
 /area/command/pathfinder)
+"fm" = (
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor/shuttle_ceiling/air,
+/area/quartermaster/hangar/top)
 "fo" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
@@ -1821,6 +1841,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"gP" = (
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id_tag = "sup_office";
+	name = "Supply Desk Shutters"
+	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/door/firedoor,
+/obj/effect/paint_stripe/supply,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar/top)
 "gX" = (
 /obj/structure/disposalpipe/down{
 	dir = 8
@@ -2006,12 +2037,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/marine_bay)
+"hq" = (
+/obj/structure/flora/pottedplant/smalltree,
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/office)
 "hr" = (
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "hs" = (
 /obj/structure/bed/chair/shuttle{
@@ -2087,6 +2125,31 @@
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
 /area/storage/primary)
+"hL" = (
+/obj/item/storage/box/cups,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/lounge)
+"hM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/lounge)
+"hN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "hO" = (
 /obj/structure/rack,
 /obj/random/tech_supply,
@@ -2465,12 +2528,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/forestarboard)
-"jr" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
 "ju" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -2539,6 +2596,16 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"jM" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/hand_cart{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/turbolift/cargo_lift)
 "jX" = (
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced/airless,
@@ -2996,6 +3063,14 @@
 /obj/machinery/suit_cycler/security/prepared,
 /turf/simulated/floor/tiled/dark,
 /area/eva)
+"lR" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/shuttle_ceiling/air,
+/area/quartermaster/hangar/top)
 "lU" = (
 /obj/structure/catwalk,
 /obj/structure/handrail{
@@ -3255,20 +3330,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/command/pathfinder)
-"mz" = (
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/corner/brown/half,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/office)
 "mB" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -3598,6 +3659,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"nQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/effect/paint_stripe/supply,
+/turf/simulated/wall/map_preset/tan,
+/area/quartermaster/sorting)
 "nT" = (
 /obj/structure/bed/roller/ironingboard,
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -3664,6 +3733,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/fore)
+"oq" = (
+/obj/machinery/vending/snack{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/office)
 "os" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 1
@@ -3988,6 +4069,17 @@
 /obj/effect/paint/tan,
 /turf/simulated/floor/plating,
 /area/crew_quarters/lounge)
+"pH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/button/blast_door{
+	id_tag = "mail_room";
+	name = "Mailroom Shutter Control";
+	pixel_x = 28;
+	pixel_y = -25;
+	req_access = newlist()
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "pJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4284,6 +4376,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
+"qK" = (
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/open,
+/area/quartermaster/hangar/top)
 "qQ" = (
 /obj/machinery/door/airlock/external{
 	icon_state = "closed";
@@ -4450,13 +4550,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/center)
-"rm" = (
-/obj/structure/railing/mapped,
-/obj/machinery/light/spot{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/quartermaster/hangar/top)
 "rn" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/rack,
@@ -4474,22 +4567,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
 "rs" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "2-4"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "rt" = (
@@ -4506,6 +4592,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
+"rx" = (
+/obj/effect/paint_stripe/supply,
+/turf/simulated/wall/map_preset/tan,
+/area/quartermaster/hangar/top)
 "rz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -4988,6 +5078,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"sW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id_tag = "mail_room";
+	name = "Mail Room Shutters"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/quartermaster/sorting)
 "sX" = (
 /obj/structure/bed/chair/padded/red{
 	dir = 8;
@@ -5075,6 +5181,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"tf" = (
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Sorting Office";
+	sort_type = "Sorting Office"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "tg" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -5218,15 +5338,8 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fourthdeck)
-"tz" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/paint_stripe/supply,
-/turf/simulated/floor/plating,
-/area/quartermaster/sorting)
 "tA" = (
-/obj/effect/floor_decal/corner/brown/half,
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
 "tC" = (
@@ -5516,15 +5629,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
 "uq" = (
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	id_tag = "sup_office";
-	name = "Supply Desk Shutters"
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 8
 	},
-/obj/effect/wallframe_spawn/reinforced/no_grille,
-/obj/machinery/door/firedoor,
-/obj/effect/paint_stripe/supply,
-/turf/simulated/floor/plating,
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/item/storage/firstaid/regular,
+/turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "ur" = (
 /obj/structure/sign/warning/high_voltage{
@@ -5542,7 +5654,7 @@
 /area/quartermaster/expedition/storage)
 "uw" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "uA" = (
 /obj/structure/closet/jcloset_torch,
@@ -5736,6 +5848,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
+"vg" = (
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 8
+	},
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/office)
 "vh" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -6091,6 +6221,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
+"ws" = (
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id_tag = "sup_office";
+	name = "Supply Office Shutters"
+	},
+/obj/effect/wallframe_spawn/reinforced/no_grille,
+/obj/machinery/door/firedoor,
+/obj/effect/paint_stripe/supply,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar/top)
 "wt" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/waterstore)
@@ -6281,6 +6422,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
+"wU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/quartermaster/hangar/top)
 "wW" = (
 /obj/machinery/door/blast/regular/escape_pod,
 /turf/simulated/floor/reinforced/airless,
@@ -6639,14 +6787,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/security/hangcheck)
-"yj" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/storage/upper)
 "yl" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -6663,6 +6803,21 @@
 "yp" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/hangar/top)
+"yr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "yt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -6670,19 +6825,36 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"yu" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
+"yw" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/cargo_lift)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/item/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/wrapping_paper,
+/obj/item/stack/package_wrap/twenty_five,
+/obj/item/hand_labeler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "yy" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -6782,6 +6954,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"zi" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/sorting)
 "zj" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/eva)
@@ -6838,7 +7017,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "zp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7154,26 +7333,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/eva)
 "At" = (
-/obj/structure/table{
-	name = "plastic table frame"
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/storage/belt/utility,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/recharger/wallcharger{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = -3
-	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/sign/warning/moving_parts,
+/obj/effect/paint_stripe/supply,
+/turf/simulated/wall/map_preset/tan,
 /area/quartermaster/office)
 "AC" = (
 /obj/structure/catwalk,
@@ -7305,15 +7467,10 @@
 /turf/simulated/open,
 /area/hallway/primary/fourthdeck/aft)
 "Bf" = (
-/obj/effect/floor_decal/techfloor{
+/obj/effect/shuttle_landmark/lift/cargo_top,
+/obj/effect/floor_decal/corner/brown{
 	dir = 8
 	},
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/obj/effect/floor_decal/corner/brown,
-/obj/effect/shuttle_landmark/lift/cargo_top,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
 "Bm" = (
@@ -7529,14 +7686,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/fourthdeck/aft)
-"Cg" = (
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/shuttle_ceiling/air,
-/area/quartermaster/hangar/top)
 "Ci" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 9
@@ -7545,15 +7694,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Cr" = (
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	id_tag = "sup_office";
-	name = "Supply Office Shutters"
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
 	},
-/obj/effect/wallframe_spawn/reinforced/no_grille,
-/obj/machinery/door/firedoor,
-/obj/effect/paint_stripe/supply,
-/turf/simulated/floor/plating,
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "Cs" = (
 /obj/structure/railing/mapped{
@@ -7613,6 +7758,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
+"CL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "CN" = (
 /obj/structure/closet/crate,
 /obj/random/junk,
@@ -7766,22 +7927,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "Dl" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/effect/paint_stripe/supply,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "Dq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Maintenance"
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "Dr" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Ds" = (
 /obj/effect/paint_stripe/supply,
@@ -7791,6 +7956,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
+"Dv" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/lounge)
 "Dw" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -7807,6 +7979,18 @@
 /obj/machinery/suit_cycler/engineering/alt,
 /turf/simulated/floor/tiled/dark,
 /area/eva)
+"Dy" = (
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/office)
 "DA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7975,12 +8159,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/laundry)
-"Em" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/office)
 "En" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8014,6 +8192,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "Eq" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 6
@@ -8201,6 +8385,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"Fc" = (
+/obj/effect/paint_stripe/common,
+/turf/simulated/wall/map_preset/tan,
+/area/quartermaster/hangar/top)
 "Fd" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
@@ -8392,27 +8580,14 @@
 /area/crew_quarters/lounge)
 "FD" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
-"FI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/vending/snack{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
-"FK" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/quartermaster/sorting)
 "FL" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 8
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "FM" = (
 /obj/effect/floor_decal/corner/brown{
@@ -8464,6 +8639,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
+"FW" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "FY" = (
 /obj/structure/closet/crate,
 /obj/random/plushie,
@@ -8586,32 +8768,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Gq" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
 /obj/machinery/light/small,
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
-"Gr" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/vending/cigarette{
-	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
@@ -8758,24 +8920,30 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/aft)
-"GW" = (
-/turf/simulated/wall/map_preset/tan,
-/area/maintenance/fourthdeck/port)
+"GV" = (
+/obj/structure/table{
+	name = "plastic table frame"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/recharger/wallcharger{
+	dir = 4;
+	pixel_x = -23;
+	pixel_y = -3
+	},
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/item/chems/spray/cleaner,
+/obj/item/storage/bag/trash,
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/office)
 "GX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod8/station)
 "GY" = (
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/machinery/vending/snack{
 	dir = 1
-	},
-/obj/item/storage/box/cups,
-/obj/structure/table/woodentable,
-/turf/simulated/floor/wood/walnut,
-/area/crew_quarters/lounge)
-"GZ" = (
-/obj/machinery/vending/games{
-	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
@@ -8803,6 +8971,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
+"Hj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "Hm" = (
 /obj/structure/cable{
 	icon_state = "16-0"
@@ -8910,16 +9085,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "HL" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/obj/effect/floor_decal/corner/brown{
-	dir = 4
-	},
 /obj/machinery/computer/shuttle_control/lift/cargo,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
@@ -9247,7 +9412,7 @@
 /turf/simulated/floor/crystal,
 /area/crew_quarters/adherent)
 "IF" = (
-/obj/structure/bed/chair/padded/brown{
+/obj/structure/bed/chair/office/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -9319,9 +9484,6 @@
 /area/quartermaster/sorting)
 "IY" = (
 /obj/machinery/disposal,
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -9390,9 +9552,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/flightcontrol)
 "Js" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "Jt" = (
@@ -9706,20 +9868,15 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Kw" = (
-/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "Kx" = (
@@ -9764,29 +9921,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "KD" = (
-/obj/machinery/fabricator,
-/obj/effect/floor_decal/corner/brown/half,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/paint_stripe/supply,
+/turf/simulated/floor/plating,
 /area/quartermaster/office)
-"KE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/mining{
-	id_tag = null;
-	name = "Mail Room"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/quartermaster/sorting)
 "KF" = (
 /obj/effect/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -9819,6 +9959,10 @@
 "KI" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/quartermaster/expedition/storage)
+"KJ" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/steel_grid,
+/area/turbolift/cargo_lift)
 "KK" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -9848,21 +9992,9 @@
 /turf/simulated/floor/bluegrid,
 /area/maintenance/fourthdeck/starboard)
 "KQ" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Sorting Office";
-	sort_type = "Sorting Office"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/sorting)
 "KR" = (
@@ -9943,7 +10075,7 @@
 /obj/item/book/manual/medical_diagnostics_manual,
 /obj/item/book/manual/nuclear,
 /obj/item/book/manual/detective,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Lj" = (
 /obj/structure/cable/green{
@@ -9991,17 +10123,23 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "Lq" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 8
-	},
 /obj/structure/table{
 	name = "plastic table frame"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/folder/red{
-	pixel_x = -3
+/obj/effect/floor_decal/corner/brown/half,
+/obj/item/stack/material/sheet/mapped/steel/fifty,
+/obj/item/stack/material/pane/mapped/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/item/folder/blue,
+/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
+	amount = 30
+	},
+/obj/item/stack/material/shiny/mapped/aluminium/fifty,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "Lu" = (
@@ -10137,8 +10275,10 @@
 /turf/simulated/floor/bluegrid,
 /area/maintenance/fourthdeck/starboard)
 "LN" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "LO" = (
@@ -10227,9 +10367,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Ma" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -10295,7 +10432,7 @@
 /area/maintenance/fourthdeck/aft)
 "Ml" = (
 /obj/machinery/fabricator/book,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Mm" = (
 /obj/structure/catwalk,
@@ -10410,23 +10547,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
-"My" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 21
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/office)
 "MB" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -10547,7 +10667,7 @@
 /obj/item/book/manual/anomaly_testing,
 /obj/item/book/manual/materials_chemistry_analysis,
 /obj/item/book/manual/stasis,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Nc" = (
 /obj/structure/cable/green{
@@ -10659,7 +10779,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Np" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10970,20 +11090,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel_grid,
 /area/janitor/storage)
-"On" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/sorting)
 "Or" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -11052,6 +11158,12 @@
 	},
 /turf/simulated/open,
 /area/hallway/primary/fourthdeck/fore)
+"OH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/office)
 "OJ" = (
 /obj/machinery/computer/modular/preset/security{
 	dir = 1;
@@ -11194,7 +11306,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Pf" = (
 /obj/machinery/door/firedoor,
@@ -11222,21 +11334,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
 "Ph" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/sorting)
 "Pi" = (
@@ -11362,7 +11460,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "PE" = (
 /obj/structure/cable/green{
@@ -11420,7 +11518,10 @@
 /area/crew_quarters/laundry)
 "PK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/spline/fancy/wood/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "PM" = (
 /turf/simulated/wall/r_wall/map_preset/tan,
@@ -11460,18 +11561,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "PQ" = (
-/obj/effect/floor_decal/corner/brown/half,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/mining{
+	id_tag = null;
+	name = "Mail Room"
+	},
 /obj/structure/cable/green{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/office)
 "PR" = (
 /obj/structure/railing/mapped{
@@ -11567,15 +11666,13 @@
 /area/maintenance/fourthdeck/foreport)
 "Qe" = (
 /obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/closet/secure_closet/decktech,
-/obj/item/coin/silver{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
+	},
+/obj/structure/hand_cart{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
@@ -11663,11 +11760,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
 "Qt" = (
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/machinery/vending/cigarette{
 	dir = 1
 	},
-/obj/machinery/recharger,
-/obj/structure/table/woodentable,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Qu" = (
@@ -11755,6 +11850,10 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
 "QL" = (
@@ -11830,8 +11929,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
 "Rb" = (
-/obj/structure/bed/chair/padded/brown,
-/turf/simulated/floor/tiled,
+/obj/machinery/fabricator,
+/obj/effect/floor_decal/corner/brown/half,
+/turf/simulated/floor/tiled/monotile,
 /area/quartermaster/office)
 "Re" = (
 /obj/machinery/network/pager/cargo{
@@ -11857,7 +11957,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Rg" = (
 /obj/structure/railing/mapped{
@@ -12066,21 +12166,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "RM" = (
-/obj/effect/floor_decal/corner/brown{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -12345,6 +12442,10 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/structure/railing/mapped{
+	dir = 8;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/open,
 /area/quartermaster/storage/upper)
 "Sy" = (
@@ -12510,7 +12611,7 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "SQ" = (
 /obj/effect/paint_stripe/command,
@@ -12683,10 +12784,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
 "Tg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/paint_stripe/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/map_preset/tan,
 /area/quartermaster/sorting)
 "Ti" = (
@@ -12767,12 +12869,12 @@
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/storage/primary)
 "Tx" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/vending/games{
+	dir = 8
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
@@ -12958,9 +13060,14 @@
 /area/janitor/storage)
 "Uj" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/carpet,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Ul" = (
 /obj/machinery/light{
@@ -13128,14 +13235,19 @@
 /area/hallway/primary/fourthdeck/aft)
 "UI" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /obj/machinery/camera/network/supply{
 	c_tag = "Supply Office - Desk";
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/item/folder/yellow,
+/obj/item/stamp/supply,
+/obj/item/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -13292,6 +13404,10 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
 "Vd" = (
@@ -13380,12 +13496,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/marine_bay)
-"Vt" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fourthdeck/port)
 "Vv" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -13394,14 +13504,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
-"Vw" = (
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/obj/structure/filingcabinet/filingcabinet,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/office)
 "Vx" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -13446,27 +13548,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/foreport)
-"VC" = (
-/obj/structure/table{
-	name = "plastic table frame"
-	},
-/obj/effect/floor_decal/corner/brown/half{
-	dir = 1
-	},
-/obj/item/folder/yellow,
-/obj/item/stamp/supply,
-/obj/item/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/item/radio/intercom{
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/office)
 "VD" = (
 /obj/structure/railing/mapped,
 /obj/machinery/atmospherics/valve/shutoff{
@@ -13628,9 +13709,26 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Wi" = (
-/obj/structure/sign/warning/moving_parts,
-/obj/effect/paint_stripe/supply,
-/turf/simulated/wall/map_preset/tan,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	controlled = 0;
+	dir = 8;
+	external_pressure_bound = 105;
+	icon_state = "map_vent_in";
+	pump_direction = 0;
+	use_power = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "Wj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
@@ -13772,7 +13870,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "WF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13816,6 +13914,13 @@
 /obj/random_multi/single_item/boombox,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/aft)
+"WM" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/corner/brown{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/turbolift/cargo_lift)
 "WN" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -13834,6 +13939,7 @@
 /obj/machinery/atmospherics/valve/shutoff{
 	dir = 4
 	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/port)
 "WO" = (
@@ -14009,10 +14115,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/center)
 "Xr" = (
-/obj/effect/floor_decal/corner/brown/half,
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = -21
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/button/blast_door{
+	id_tag = "mail_room";
+	name = "Mailroom Shutter Control";
+	pixel_x = -25;
+	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/storage/upper)
@@ -14031,7 +14139,10 @@
 	c_tag = "Fourth Deck - Lounge Fore";
 	name = "security camera"
 	},
-/turf/simulated/floor/carpet,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Xv" = (
 /obj/effect/floor_decal/corner/brown{
@@ -14267,25 +14378,18 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage/upper)
 "XY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/sorting)
@@ -14348,6 +14452,21 @@
 "Ym" = (
 /turf/simulated/open,
 /area/hallway/primary/fourthdeck/aft)
+"Yo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/storage/upper)
 "Yp" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/dark,
@@ -14360,17 +14479,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fourthdeck/foreport)
 "Ys" = (
-/obj/structure/table{
-	name = "plastic table frame"
-	},
-/obj/item/stack/material/pane/mapped/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/material/sheet/mapped/steel/fifty,
-/obj/effect/floor_decal/corner/brown/half,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/monotile,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint_stripe/supply,
+/turf/simulated/floor/plating,
 /area/quartermaster/office)
 "Yt" = (
 /obj/structure/cable{
@@ -14472,7 +14583,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "YE" = (
 /obj/machinery/firealarm{
@@ -14639,7 +14750,7 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
 "Za" = (
 /obj/structure/rack,
@@ -14700,6 +14811,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/starboard)
+"Zh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fourthdeck/port)
 "Zj" = (
 /obj/effect/floor_decal/corner/red,
 /obj/effect/floor_decal/corner/white{
@@ -14714,38 +14837,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Zl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/obj/machinery/atmospherics/unary/vent_pump{
-	controlled = 0;
-	dir = 8;
-	external_pressure_bound = 105;
-	icon_state = "map_vent_in";
-	pump_direction = 0;
-	use_power = 1
-	},
-/obj/structure/table{
-	name = "plastic table frame"
-	},
-/obj/item/destTagger{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/stack/package_wrap/twenty_five,
-/obj/item/hand_labeler,
-/obj/item/wrapping_paper,
-/obj/machinery/light/spot{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "Zm" = (
@@ -14782,7 +14877,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Zq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14791,7 +14886,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "Zr" = (
 /obj/effect/floor_decal/corner/research/three_quarters,
@@ -14821,26 +14916,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/sorting)
-"Zv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1;
-	icon_state = "warningcorner"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/quartermaster/sorting)
 "Zw" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14936,6 +15011,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/tcommsat/network_relay/d4)
+"ZI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/quartermaster/sorting)
 "ZJ" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -14984,12 +15068,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fourthdeck/starboard)
 "ZN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
@@ -15046,7 +15133,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "ZV" = (
 /obj/item/stool/bar/padded,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/walnut,
 /area/crew_quarters/lounge)
 "ZW" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -30542,8 +30629,8 @@ rp
 Ga
 Ga
 Ga
-Ga
-rm
+mG
+lr
 lr
 ta
 Sl
@@ -30744,8 +30831,8 @@ rp
 Ga
 Ga
 Ga
-Ga
 mG
+lr
 lr
 ta
 Ww
@@ -30946,8 +31033,8 @@ vJ
 aY
 aY
 aY
-aY
 Wf
+WI
 WI
 Rj
 Wp
@@ -31148,8 +31235,8 @@ vJ
 aY
 aY
 aY
-aY
 Wf
+WI
 WI
 Qd
 Yl
@@ -31350,8 +31437,8 @@ HE
 aY
 aY
 aY
-aY
 Wf
+WI
 WI
 Sd
 iS
@@ -31552,15 +31639,15 @@ rp
 wS
 wS
 wS
-wS
-Cg
+Cs
+WI
 WI
 Yd
 WD
 hr
 YD
 SP
-jr
+Wh
 uw
 iS
 Db
@@ -31759,9 +31846,9 @@ WI
 WI
 Yd
 ZV
-TY
+RY
 PC
-MY
+UD
 YZ
 Ml
 iS
@@ -31956,9 +32043,9 @@ Tp
 Tp
 Tp
 Tp
-Tp
-mB
+fm
 WI
+Fc
 Sd
 Xt
 PK
@@ -32158,12 +32245,12 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
-Yd
+cj
 Wh
 TY
+MY
 Zk
 iS
 Vq
@@ -32360,12 +32447,12 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
-Yd
+cj
 ER
 FB
+MY
 Zk
 iS
 Hv
@@ -32562,19 +32649,19 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
-Yd
+cj
 ES
 TY
-Zk
 MY
+Zk
+RY
 RY
 RY
 RY
 OO
-UD
+CH
 JG
 pG
 sJ
@@ -32764,14 +32851,14 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
+Fc
 Sd
 ET
 FD
 Nn
-SP
+hM
 RY
 RY
 RY
@@ -32966,12 +33053,12 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
-Yd
+cj
 Wh
 TY
+MY
 zo
 IY
 RV
@@ -33168,12 +33255,12 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
-Yd
+cj
 XZ
 FB
+MY
 Rf
 iS
 iS
@@ -33370,12 +33457,12 @@ aY
 aY
 aY
 aY
-aY
 Wf
 WI
-Yd
+cj
 ES
-TY
+hL
+MY
 Gp
 GY
 iS
@@ -33572,12 +33659,12 @@ Ga
 aY
 aY
 aY
-aY
 Wf
 WI
+Fc
 Sd
 EW
-PK
+Dv
 Pe
 Qt
 iS
@@ -33774,12 +33861,12 @@ Ga
 Ga
 Ga
 Ga
-Ga
 mG
 lr
-Yd
+cj
 Wh
 TY
+MY
 Gp
 Gq
 iS
@@ -33976,12 +34063,12 @@ Ga
 Ga
 Ga
 Ga
-Ga
 mG
 lr
-Yd
+cj
 EY
 FB
+MY
 Zp
 Ma
 HB
@@ -34178,12 +34265,12 @@ Ga
 Ga
 Ga
 Ga
-Ga
 mG
 lr
-Yd
+cj
 EZ
 TY
+MY
 Uj
 Tx
 iS
@@ -34379,15 +34466,15 @@ Ga
 Ob
 Ga
 Ga
-Ga
-Ga
-mG
+Rg
+qK
 lr
+Fc
 Sd
 Sd
-FI
-Gr
-GZ
+iS
+iS
+iS
 iS
 Ie
 Of
@@ -34580,24 +34667,24 @@ MU
 MU
 Wv
 Ga
-aY
-aY
-wS
-Cs
+Wf
+WI
+lR
 WI
 yp
-Sd
-iS
-iS
-iS
-iS
+yp
+eJ
+Ni
+Ni
+Ni
+Ni
 If
 kw
 XL
 PU
 KK
 GT
-Gt
+GT
 Gt
 Gt
 Gt
@@ -34782,24 +34869,24 @@ RD
 Jq
 OL
 aY
-aY
 Wf
 WI
-WI
-WI
-yp
-eJ
-Ni
-Ni
-Ni
+rx
+gP
+gP
+gP
+eU
+eU
+eU
+eU
 Ni
 AC
 Iv
 ok
 Js
 Kw
+bK
 GT
-Gt
 Gt
 Gt
 Gt
@@ -34984,24 +35071,24 @@ sX
 uC
 OL
 aY
-aY
 Wf
 WI
-vQ
+ws
+Dy
 uq
 Dq
-vQ
-vQ
-vQ
+oq
+vg
+GV
 vQ
 sh
 sh
 UL
 Tg
+nQ
 sh
 RS
 GT
-Gt
 Gt
 Gt
 Gt
@@ -35186,24 +35273,24 @@ sY
 uD
 SQ
 aY
-aY
 Wf
 WI
+ws
 Cr
 Dr
-Em
-Em
+yy
+yy
 FL
 Lq
 At
 sh
 PG
 XY
+yw
 IX
 sh
 RS
 GT
-Gt
 Gt
 Gt
 Gt
@@ -35388,11 +35475,11 @@ sZ
 SQ
 SQ
 HY
-wS
-Cg
+Cs
 WI
-Cr
-Vw
+ws
+hq
+yy
 yy
 Fb
 Lo
@@ -35401,12 +35488,12 @@ Ys
 Dl
 LN
 Ph
+yr
 Ox
 sh
 RS
 GT
 GT
-Gt
 Gt
 Gt
 Gt
@@ -35592,23 +35679,23 @@ qU
 lr
 WI
 WI
-WI
-vQ
-VC
+wU
+yy
+yy
 yy
 yy
 uo
-yy
+OH
 KD
-tz
 kS
+ZI
 KQ
+tf
 WJ
 sh
 JL
 rG
 GT
-Gt
 Gt
 Gt
 Gt
@@ -35800,17 +35887,17 @@ jB
 IF
 UI
 mo
-yy
-mz
-sh
+Ep
+Ys
 Zu
-Zv
+Hj
+Ph
+CL
 zl
 sh
 JL
 LC
 GT
-Gt
 Gt
 Gt
 Gt
@@ -36004,15 +36091,15 @@ vQ
 YS
 ZN
 PQ
-KE
 Yz
-On
+zi
+zi
+hN
 yG
 sh
 JL
 rn
 GT
-Gt
 Gt
 Gt
 Gt
@@ -36205,16 +36292,16 @@ Vf
 SS
 XA
 RM
-My
+Ys
 Wi
 Zl
+pH
 Vv
 en
 sh
 JL
 WY
 GT
-Gt
 Gt
 Gt
 Gt
@@ -36408,15 +36495,15 @@ Yf
 Yf
 QI
 Yf
-sh
-FK
+sW
+sW
+sW
 sh
 sh
 sh
 JM
-GW
 GT
-Gt
+GT
 Gt
 Gt
 Gt
@@ -36612,11 +36699,11 @@ Np
 Xr
 HL
 Bf
-Yf
-BH
-Vt
-rs
+WM
+eU
 Kb
+rs
+Zh
 GT
 Gt
 Gt
@@ -36814,8 +36901,8 @@ Pg
 tA
 pc
 pc
-Yf
-zx
+KJ
+eU
 Ni
 JL
 Kc
@@ -37012,12 +37099,12 @@ Qk
 Qk
 Yf
 uI
-Uh
-yj
-yu
+Yo
+tA
+pc
 ce
-Yf
-eQ
+jM
+eU
 Ni
 WA
 TW
@@ -37219,7 +37306,7 @@ QK
 Sx
 Sx
 Yf
-zx
+eU
 Ni
 xL
 Kd
@@ -37623,8 +37710,8 @@ ZB
 Vo
 ju
 Yf
-zx
-Ni
+BH
+FW
 al
 dg
 GT

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -4503,11 +4503,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/vacant/cargo)
-"ko" = (
-/obj/machinery/space_heater,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/thirddeck/port)
 "kp" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -5637,12 +5632,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
-"ny" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/ladder,
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/thirddeck/port)
 "nz" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -6116,6 +6105,13 @@
 /obj/random/drinkbottle,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/recreation)
+"oQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/port)
 "oT" = (
 /obj/structure/railing/mapped{
 	dir = 1;
@@ -6609,8 +6605,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
 "qg" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "qh" = (
@@ -7103,10 +7099,8 @@
 /obj/structure/rack{
 	dir = 8
 	},
-/obj/random/action_figure,
-/obj/random/action_figure,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
+/obj/random/material,
+/obj/random/material,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
 "rE" = (
@@ -8138,13 +8132,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"ug" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/port)
 "uh" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/rack{
@@ -8468,16 +8455,6 @@
 /obj/machinery/power/apc/critical,
 /turf/simulated/floor/tiled/techfloor,
 /area/thruster/d3starboard)
-"vk" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/port)
 "vm" = (
 /obj/machinery/door/airlock/chaplain{
 	name = "Chapel"
@@ -9259,8 +9236,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/hardstorage)
 "xw" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "xx" = (
@@ -9596,6 +9575,20 @@
 /obj/effect/floor_decal/corner/green,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"yn" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/cargo)
 "yp" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -10158,10 +10151,15 @@
 /area/thruster/d3starboard)
 "Al" = (
 /obj/random/torchcloset,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/target/syndicate,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/drinkbottle,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
+/obj/random/drinkingglass,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
 "Am" = (
@@ -10494,6 +10492,12 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
+"Bx" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/ladder,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/cargo)
 "By" = (
 /obj/structure/hygiene/shower{
 	dir = 8
@@ -10671,6 +10675,12 @@
 /obj/random/tank,
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
+"Ci" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/port)
 "Cj" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -11785,18 +11795,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/thirddeck/port)
-"Fg" = (
-/obj/structure/rack{
-	dir = 8
-	},
-/obj/random/bomb_supply,
-/obj/random/bomb_supply,
-/obj/random/bomb_supply,
-/obj/random/bomb_supply,
-/obj/random/bomb_supply,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled/techfloor,
-/area/vacant/cargo)
 "Fh" = (
 /obj/structure/rack{
 	dir = 8
@@ -11804,7 +11802,11 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/obj/random/junk,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
@@ -11942,6 +11944,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
+"FA" = (
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/obj/random/maintenance/solgov,
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/cargo)
 "FB" = (
 /obj/effect/paint/eggshell,
 /obj/effect/paint_stripe/common,
@@ -12146,18 +12159,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vacant/cargo)
-"Gk" = (
-/obj/structure/rack{
-	dir = 8
-	},
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/tech_supply,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
+/obj/random/single/cola,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
 "Gl" = (
@@ -12168,10 +12170,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/vacant/cabin)
-"Gn" = (
-/obj/item/toy/desk/fan,
-/turf/simulated/floor/tiled/techfloor,
-/area/vacant/cargo)
 "Gp" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/dark,
@@ -12354,16 +12352,10 @@
 /obj/structure/rack{
 	dir = 8
 	},
-/obj/random/junk,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled/techfloor,
-/area/vacant/cargo)
-"GK" = (
-/obj/structure/rack{
-	dir = 8
-	},
-/obj/random/single/cola,
-/obj/random/maintenance/solgov,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
@@ -12618,20 +12610,6 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
-"HF" = (
-/obj/structure/rack{
-	dir = 8
-	},
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled/techfloor,
-/area/vacant/cargo)
 "HG" = (
 /obj/structure/largecrate,
 /obj/random/maintenance/solgov,
@@ -13437,11 +13415,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/habcheck)
-"Kf" = (
-/obj/random/torchcloset,
-/obj/random/maintenance/solgov,
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/port)
 "Kg" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/thruster/d3starboard)
@@ -14450,6 +14423,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
+"Oi" = (
+/obj/random/torchcloset,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/obj/random/maintenance/solgov/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "Oj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/steel,
@@ -15222,6 +15202,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/gym)
+"QW" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/port)
 "QX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/cable/green{
@@ -15491,6 +15481,19 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
+"RU" = (
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/obj/random/bomb_supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/cargo)
 "RV" = (
 /obj/structure/hygiene/shower{
 	dir = 1
@@ -15616,6 +15619,12 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/sleep/dorms/two)
+"Ss" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/port)
 "St" = (
 /obj/machinery/door/airlock/external/bolted{
 	id_tag = "3rd_port_ext"
@@ -16879,6 +16888,10 @@
 	},
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftport)
+"Ws" = (
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/cargo)
 "Wu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
@@ -17740,6 +17753,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
+"Zq" = (
+/obj/structure/rack{
+	dir = 8
+	},
+/obj/item/toy/desk/fan,
+/turf/simulated/floor/tiled/techfloor,
+/area/vacant/cargo)
 "Zr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38454,7 +38474,7 @@ GN
 GN
 CV
 GN
-HD
+Ss
 Ts
 Hf
 Hf
@@ -38656,7 +38676,7 @@ FI
 Gi
 Hk
 Fi
-HD
+Ci
 Ts
 HE
 Hf
@@ -38858,8 +38878,8 @@ Gj
 GI
 Hi
 Fi
-HD
-UZ
+QW
+oQ
 qK
 TT
 Yh
@@ -39060,7 +39080,7 @@ la
 Hj
 Hj
 GN
-vk
+GN
 xw
 qg
 TT
@@ -39259,10 +39279,10 @@ qi
 So
 Fi
 FJ
-Gk
+GI
 GJ
-Fi
-Ts
+yn
+GN
 Ts
 HG
 Hf
@@ -39462,10 +39482,10 @@ JV
 kl
 qp
 td
-HF
-Fi
-ko
-ny
+GI
+Bx
+GN
+Ts
 Hf
 Hf
 Hf
@@ -39664,10 +39684,10 @@ zl
 Fi
 qW
 wm
-GK
-Fi
-ug
-Hf
+Gl
+si
+GN
+xm
 Hf
 aa
 aa
@@ -39865,12 +39885,12 @@ tZ
 EB
 GN
 GN
+GN
 zx
 GN
 GN
 xm
 Hf
-aa
 aa
 aa
 aa
@@ -40067,12 +40087,12 @@ jt
 uX
 Fi
 rD
+RU
 Gl
 Fi
-Kf
+xm
 xm
 Hf
-aa
 aa
 aa
 aa
@@ -40268,13 +40288,13 @@ Nq
 CE
 xm
 Fi
-Fg
-Gl
+GI
+GI
+GI
 Fi
-uX
 zZ
-jZ
-aa
+uX
+Hf
 aa
 aa
 aa
@@ -40471,12 +40491,12 @@ CE
 xm
 Fi
 Fh
-Gl
+FA
+GI
 GN
 Ba
-Ba
+Oi
 jZ
-aa
 aa
 aa
 aa
@@ -40672,13 +40692,13 @@ Nq
 CE
 xm
 Fi
-si
-Gn
+GI
+GI
+GI
 GN
 Ba
-Ba
 jZ
-aa
+jZ
 aa
 aa
 aa
@@ -40874,10 +40894,10 @@ Nq
 CE
 xm
 Fi
-si
+Ws
 Al
+Zq
 GN
-Ba
 Ba
 jZ
 aa
@@ -41079,7 +41099,7 @@ GN
 GN
 GN
 GN
-Bc
+GN
 Ba
 jZ
 aa

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -8843,6 +8843,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"vI" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/storage/cargo)
 "vJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -10487,6 +10493,10 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/synth/borg_upload)
+"Av" = (
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/storage/cargo)
 "Ay" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/structure/cable{
@@ -10709,6 +10719,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
+"AU" = (
+/obj/item/stool/padded,
+/turf/simulated/floor/tiled/techfloor,
+/area/storage/cargo)
 "AX" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -11028,6 +11042,12 @@
 	name = "north bump";
 	pixel_y = 24
 	},
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/item/cell/high,
+/obj/item/cell/high,
+/obj/random/powercell,
+/obj/random/powercell,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "Ce" = (
@@ -11040,13 +11060,27 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology)
 "Cf" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/rack,
+/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
+	amount = 30
 	},
-/obj/machinery/alarm{
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
+	amount = 30
 	},
+/obj/item/stack/material/reinforced/mapped/fiberglass/fifty{
+	amount = 30
+	},
+/obj/item/stack/material/reinforced/mapped/plasteel/fifty,
+/obj/item/stack/material/sheet/mapped/steel/fifty{
+	amount = 30
+	},
+/obj/item/stack/material/sheet/mapped/steel/fifty{
+	amount = 30
+	},
+/obj/item/stack/material/sheet/mapped/steel/fifty{
+	amount = 30
+	},
+/obj/item/stack/material/shiny/mapped/aluminium/fifty,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "Cg" = (
@@ -11179,7 +11213,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/fuelbay/aux)
 "CB" = (
-/obj/random/toolbox,
+/obj/structure/table/steel,
+/obj/item/storage/toolbox/repairs,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "CC" = (
@@ -11392,15 +11427,16 @@
 /area/storage/cargo)
 "Dd" = (
 /obj/structure/table/steel,
-/obj/machinery/cell_charger,
-/obj/item/cell/high,
-/obj/random/powercell,
-/obj/random/powercell,
+/obj/item/flashlight/lamp/lava/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "De" = (
-/obj/structure/closet/secure_closet/decktech,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/closet/secure_closet/decktech,
+/obj/item/coin/silver{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "Df" = (
@@ -11557,16 +11593,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/r_wall/map_preset/tan,
 /area/rnd/xenobiology/entry)
-"Dw" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/storage/cargo)
-"Dx" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/storage/cargo)
 "Dy" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -11684,14 +11710,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/entry)
-"DT" = (
-/obj/random/tank,
-/turf/simulated/floor/tiled/techfloor,
-/area/storage/cargo)
-"DU" = (
-/obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/tiled/techfloor,
-/area/storage/cargo)
 "DV" = (
 /obj/structure/closet/secure_closet/crew/research,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -17254,6 +17272,11 @@
 "TV" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/alarm{
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/cargo)
 "TW" = (
@@ -38619,7 +38642,7 @@ AN
 AN
 Dc
 Dc
-ag
+Hb
 Hb
 Hb
 ED
@@ -38822,7 +38845,7 @@ CB
 Dd
 Dc
 Dc
-Hb
+Dc
 Hb
 ED
 WY
@@ -39021,9 +39044,9 @@ SM
 AO
 NB
 Bs
+AU
 Bs
-Dw
-Dc
+Av
 Dc
 Hb
 Hb
@@ -39225,7 +39248,7 @@ TV
 Bs
 Bs
 Bs
-DT
+Bs
 Dc
 Hb
 Hb
@@ -39424,10 +39447,10 @@ Yy
 zS
 AN
 Cf
-Bs
+vI
 De
-Dx
-DU
+De
+De
 Dc
 Hb
 Hb


### PR DESCRIPTION
AUTHOR'S NOTE: Everything conflicts, please tell me what I did wrong
 
Remaps supply:
D5: Warehouse is reorganised so that the 'back row' of crates can be reached. Moved materials into D2 closet. Added more crates. Expanded room for lift. Added crate of conveyor assemblies.
D4: Expands supply room to have 3 seats and a vending machine. Mail room is slightly bigger. Supply lift is 3x3 tiles instead of 3x2, for more crates. DT lockers were moved to D2 closet, two extra handcarts added in their place.
D3: Maint ladder was moved to accomodate for elevator/disposal room expansion.
D2: Supply closet reworked to be less like a room full of junk, and more like a room full of slightly more relevant junk