### PR TITLE
Removes Lube

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/robots.dm
+++ b/code/game/objects/effects/decals/Cleanable/robots.dm
@@ -8,7 +8,7 @@
 	cleanable_scent = "industrial lubricant"
 	scent_intensity = /decl/scent_intensity/normal
 	scent_range = 2
-	chemical = /decl/material/liquid/lube
+	chemical = /decl/material/liquid/water
 
 /obj/effect/decal/cleanable/blood/gibs/robot/on_update_icon()
 	color = "#ffffff"
@@ -41,7 +41,7 @@
 
 /obj/effect/decal/cleanable/blood/oil
 	basecolor = SYNTH_BLOOD_COLOUR
-	chemical = /decl/material/liquid/lube
+	chemical = /decl/material/liquid/water
 
 /obj/effect/decal/cleanable/blood/oil/dry()
 	return

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -242,7 +242,7 @@
 	seed_name = "blue tomato"
 	display_name = "blue tomato plant"
 	mutants = list("quantumato")
-	chems = list(/decl/material/liquid/nutriment = list(1,20), /decl/material/liquid/lube = list(1,5))
+	chems = list(/decl/material/liquid/nutriment = list(1,20), /decl/material/liquid/water = list(1,5))
 
 /datum/seed/tomato/blue/New()
 	..()

--- a/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
+++ b/code/modules/materials/definitions/liquids/materials_liquid_chemistry.dm
@@ -14,11 +14,4 @@
 	color = "#664b63"
 	value = 0.1
 
-/decl/material/liquid/lube
-	name = "lubricant"
-	uid = "liquid_lubricant"
-	lore_text = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
-	taste_description = "slime"
-	color = SYNTH_BLOOD_COLOUR
-	value = 0.1
-	slipperiness = 80
+

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -25,8 +25,8 @@
 
 /obj/item/robot_module/janitor/finalize_emag()
 	. = ..()
-	emag.reagents.add_reagent(/decl/material/liquid/lube, 250)
-	emag.SetName("Lube spray")
+	emag.reagents.add_reagent(/decl/material/liquid/water, 250)
+	emag.SetName("Water spray")
 
 /obj/item/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	..()
@@ -34,4 +34,4 @@
 	LR.Charge(R, amount)
 	if(emag)
 		var/obj/item/chems/spray/S = emag
-		S.reagents.add_reagent(/decl/material/liquid/lube, 20 * amount)
+		S.reagents.add_reagent(/decl/material/liquid/water, 20 * amount)

--- a/code/modules/reagents/reactions/reaction_drugs.dm
+++ b/code/modules/reagents/reactions/reaction_drugs.dm
@@ -30,13 +30,6 @@
 	minimum_temperature = 50 CELSIUS
 	maximum_temperature = (50 CELSIUS) + 100
 
-/decl/chemical_reaction/lube
-	name = "Lubricant"
-	result = /decl/material/liquid/lube
-	required_reagents = list(/decl/material/liquid/water = 1, /decl/material/solid/silicon = 1, /decl/material/liquid/acetone = 1)
-	result_amount = 4
-	mix_message = "The solution becomes thick and slimy."
-
 /decl/chemical_reaction/pacid
 	name = "Polytrinic acid"
 	result = /decl/material/liquid/acid/polyacid
@@ -110,7 +103,7 @@
 /decl/chemical_reaction/nanitefluid
 	name = "Nanite Fluid"
 	result = /decl/material/liquid/nanitefluid
-	required_reagents = list(/decl/material/liquid/plasticide = 1, /decl/material/solid/metal/aluminium = 1, /decl/material/liquid/lube = 1)
+	required_reagents = list(/decl/material/liquid/plasticide = 1, /decl/material/solid/metal/aluminium = 1, /decl/material/liquid/water = 1)
 	catalysts = list(/decl/material/liquid/crystal_agent = 1)
 	result_amount = 3
 	minimum_temperature = (-25 CELSIUS) - 100

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -46,7 +46,7 @@
 		log_and_message_admins("fired sulphuric acid from \a [src].", user)
 	if(reagents.has_reagent(/decl/material/liquid/acid/polyacid))
 		log_and_message_admins("fired polyacid from \a [src].", user)
-	if(reagents.has_reagent(/decl/material/liquid/lube))
+	if(reagents.has_reagent(/decl/material/liquid/water))
 		log_and_message_admins("fired lubricant from \a [src].", user)
 	return
 

--- a/code/modules/xenoarcheaology/finds/find_types/chem_containers.dm
+++ b/code/modules/xenoarcheaology/finds/find_types/chem_containers.dm
@@ -30,7 +30,7 @@
 	. = ..()
 	spawning_id = pick(
 		/decl/material/liquid/blood,     \
-		/decl/material/liquid/lube,      \
+		/decl/material/liquid/water,      \
 		/decl/material/liquid/sedatives, \
 		/decl/material/liquid/ethanol,   \
 		/decl/material/liquid/water,   \


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

Just what it says on the tin

## Why and what will this PR improve
Lube is basically an instant win button for antags, offering no counterplay whatsoever, it can't be avoided since it's invisible, and even if it wasn't, it's far too easy to cover entire hallways with it, even without a (incredibly easy-to-obtain) Chem Sprayer. Even magboots don't do shit against it. Thought I'd just cut the problem at the source.

## Authorship

moi

## Changelog

:cl:
rscdel:Removed Space Lube.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
