### PR TITLE
Standardizes ranks.

### DIFF
--- a/maps/torch/items/hearth_clothing/attachments.dm
+++ b/maps/torch/items/hearth_clothing/attachments.dm
@@ -22,6 +22,10 @@
 	ranking = "T1"
 	ranking_full = "Technician First Class"
 
+/obj/item/clothing/accessory/rank/iseo/t5
+	ranking = "TNC"
+	ranking_full = "Chief Technician"
+
 /obj/item/clothing/accessory/rank/iseo/officer
 	icon = 'maps/torch/icons/converted_icons/accessories/rank_specialist_iseo.dmi'
 

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -12,7 +12,7 @@
 	)
 	department_types = list(/decl/department/command)
 	allowed_ranks = list(
-		/datum/mil_rank/sc/s6,
+		/datum/mil_rank/sc/s5,
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_SCIENCE     = SKILL_ADEPT,
@@ -91,7 +91,7 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/espatier/o5
+		/datum/mil_rank/espatier/o4
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
@@ -148,7 +148,7 @@
 
 /datum/job/rd
 	title = "Chief Science Officer"
-	supervisors = "the Commanding Officer"
+	supervisors = "the Commanding Officer and the Executive Officer"
 	economic_power = 12
 	minimal_player_age = 14
 	minimum_character_age = list(SPECIES_HUMAN = 35)
@@ -161,8 +161,8 @@
 		/datum/mil_branch/espatier_corps
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/espatier/o4
+		/datum/mil_rank/sc/s3,
+		/datum/mil_rank/espatier/o3
 	)
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
@@ -203,7 +203,7 @@
 	head_position = TRUE
 
 /datum/job/rd/get_description_blurb()
-	return "You are the Chief Science Officer. You are responsible for the research department. You handle the science aspects of the project and liase with the corporate interests of the Expeditionary Corps Organisation. Make sure science gets done, do some yourself, and get your scientists on away missions to find things to benefit the project. Advise the CO on science matters."
+	return "You are the Chief Science Officer. You are responsible for the research department. You handle the science aspects of the project and liase with the corporate interests of the International Stellar Exploration Organisation. Make sure science gets done, do some yourself, and get your scientists on away missions to find things to benefit the project. Advise the CO on science matters."
 
 /datum/job/cmo
 	title = "Chief Medical Officer"
@@ -220,8 +220,8 @@
 		/datum/mil_branch/espatier_corps = /decl/hierarchy/outfit/job/torch/crew/command/cmo/espatier
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/espatier/o4
+		/datum/mil_rank/sc/s3,
+		/datum/mil_rank/espatier/o3
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_MEDICAL     = SKILL_EXPERT,
@@ -274,8 +274,8 @@
 		/datum/mil_branch/espatier_corps = /decl/hierarchy/outfit/job/torch/crew/command/chief_engineer/espatier
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/espatier/o4
+		/datum/mil_rank/sc/s3,
+		/datum/mil_rank/espatier/o3
 	)
 	min_skill = list(   SKILL_BUREAUCRACY  = SKILL_BASIC,
 	                    SKILL_COMPUTER     = SKILL_ADEPT,
@@ -345,8 +345,8 @@
 		/datum/mil_branch/espatier_corps = /decl/hierarchy/outfit/job/torch/crew/command/cos/espatier
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/espatier/o4
+		/datum/mil_rank/sc/s3,
+		/datum/mil_rank/espatier/o3
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_ADEPT,
 	                    SKILL_EVA         = SKILL_BASIC,
@@ -382,7 +382,7 @@
 	head_position = TRUE
 
 /datum/job/hos/get_description_blurb()
-	return "You are the Chief of Security. You manage ship security. The Masters at Arms and the Military Police, as well as the Brig Chief and the Forensic Technician. You keep the vessel safe. You handle both internal and external security matters. You are the law. You are subordinate to the CO and the XO. You are expected to know the SCMJ and Sol law and Alert Procedure to a very high degree along with general regulations."
+	return "You are the Chief of Security. You manage ship security. The Masters at Arms, the Brig Chief and the Forensic Technician. You keep the vessel safe. You handle both internal and external security matters. You are the law. You are subordinate to the CO and the XO. You are expected to know the Ship Procedures and Standard Operating Procedures to a very high degree."
 
 /datum/job/representative
 	title = "National Council Representative"
@@ -432,9 +432,8 @@
 		/datum/mil_branch/espatier_corps
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/espatier/e8,
-		/datum/mil_rank/espatier/e9_alt1,
-		/datum/mil_rank/espatier/e9
+		/datum/mil_rank/espatier/e8_alt,
+		/datum/mil_rank/espatier/e9_alt2
 	)
 	min_skill = list(   SKILL_EVA        = SKILL_BASIC,
 	                    SKILL_COMBAT     = SKILL_BASIC,
@@ -464,7 +463,7 @@
 	selection_color = COMMS_COLOR_COMMAND
 
 /datum/job/sea/get_description_blurb()
-	return "You are the Senior Enlisted Advisor. You are the highest enlisted person on the ship. You are directly subordinate to the CO. You advise them on enlisted concerns and provide expertise and advice to officers. You are responsible for ensuring discipline and good conduct among enlisted, as well as notifying officers of any issues and \"advising\" them on mistakes they make. You also handle various duties on behalf of the CO and XO. You are an experienced enlisted person, very likely equal only in experience to the CO and XO. You know the regulations better than anyone."
+	return "You are the Senior Enlisted Advisor. You are the highest enlisted person on the ship. You are directly subordinate to the CO and XO. You advise them on enlisted concerns and provide expertise and advice to officers. You are responsible for ensuring discipline and good conduct among enlisted, as well as notifying officers of any issues and \"advising\" them on mistakes they make. You also handle various duties on behalf of the CO and XO. You are an experienced enlisted person, very likely equal only in experience to the CO and XO. You know the regulations better than anyone."
 
 /datum/job/bridgeofficer
 	title = "Bridge Officer"

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -17,6 +17,7 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/sc/t4,
+		/datum/mil_rank/sc/t5,
 		/datum/mil_rank/espatier/e6,
 		/datum/mil_rank/espatier/e7
 	)

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -98,9 +98,11 @@
 	allowed_ranks = list(
 		/datum/mil_rank/sc/t1,
 		/datum/mil_rank/sc/t2,
+		/datum/mil_rank/sc/t3,
 		/datum/mil_rank/espatier/e1,
 		/datum/mil_rank/espatier/e2,
-		/datum/mil_rank/espatier/e3
+		/datum/mil_rank/espatier/e3,
+		/datum/mil_rank/espatier/e4
 	)
 	min_skill = list(   SKILL_EVA = SKILL_BASIC,SKILL_LITERACY = SKILL_ADEPT)
 

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -18,9 +18,7 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/sc/s2,
-		/datum/mil_rank/sc/s3,
-		/datum/mil_rank/espatier/o2,
-		/datum/mil_rank/espatier/o3,
+		/datum/mil_rank/espatier/o2
 	)
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_MEDICAL     = SKILL_EXPERT,
@@ -106,8 +104,10 @@
 	allowed_ranks = list(
 		/datum/mil_rank/sc/t2,
 		/datum/mil_rank/sc/t3,
+		/datum/mil_rank/sc/t4,
 		/datum/mil_rank/espatier/e3,
-		/datum/mil_rank/espatier/e4
+		/datum/mil_rank/espatier/e4,
+		/datum/mil_rank/espatier/e5
 	)
 	min_skill = list(   SKILL_EVA     = SKILL_BASIC,
 	                    SKILL_MEDICAL = SKILL_BASIC,

--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -15,6 +15,7 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/sc/t4,
+		/datum/mil_rank/sc/t5,
 		/datum/mil_rank/espatier/e5,
 		/datum/mil_rank/espatier/e6,
 		/datum/mil_rank/espatier/e7

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -17,6 +17,7 @@
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/sc/t4,
+		/datum/mil_rank/sc/t5,
 		/datum/mil_rank/espatier/e6,
 		/datum/mil_rank/espatier/e7
 	)

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -27,7 +27,7 @@
 	species_to_rank_blacklist = list(
 		/decl/species/utility_frame = list(
 			/datum/mil_branch/iseo_issc = list(
-				/datum/mil_rank/sc/s6
+				/datum/mil_rank/sc/s5
 			),
 			/datum/mil_branch/government = list(
 				/datum/mil_rank/government/gov
@@ -35,7 +35,7 @@
 		),
 		/decl/species/lizard = list(
 			/datum/mil_branch/iseo_issc = list(
-				/datum/mil_rank/sc/s6
+				/datum/mil_rank/sc/s5
 			),
 			/datum/mil_branch/government = list(
 				/datum/mil_rank/government/gov
@@ -43,7 +43,7 @@
 		),
 		/decl/species/tajaran = list(
 			/datum/mil_branch/iseo_issc = list(
-				/datum/mil_rank/sc/s6
+				/datum/mil_rank/sc/s5
 			),
 			/datum/mil_branch/government = list(
 				/datum/mil_rank/government/gov
@@ -51,7 +51,7 @@
 		),
 		/decl/species/skrell = list(
 			/datum/mil_branch/iseo_issc = list(
-				/datum/mil_rank/sc/s6
+				/datum/mil_rank/sc/s5
 			),
 			/datum/mil_branch/government = list(
 				/datum/mil_rank/government/gov
@@ -140,11 +140,12 @@
 		/datum/mil_rank/sc/t2,
 		/datum/mil_rank/sc/t3,
 		/datum/mil_rank/sc/t4,
+		/datum/mil_rank/sc/t5,
 		/datum/mil_rank/sc/s1,
 		/datum/mil_rank/sc/s2,
 		/datum/mil_rank/sc/s3,
 		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/sc/s6
+		/datum/mil_rank/sc/s5
 	)
 
 	spawn_rank_types = list(
@@ -152,11 +153,12 @@
 		/datum/mil_rank/sc/t2,
 		/datum/mil_rank/sc/t3,
 		/datum/mil_rank/sc/t4,
+		/datum/mil_rank/sc/t5,
 		/datum/mil_rank/sc/s1,
 		/datum/mil_rank/sc/s2,
 		/datum/mil_rank/sc/s3,
 		/datum/mil_rank/sc/s4,
-		/datum/mil_rank/sc/s6
+		/datum/mil_rank/sc/s5
 	)
 
 	assistant_job = /datum/job/crew
@@ -181,7 +183,7 @@
 		/datum/mil_rank/espatier/e8,
 		/datum/mil_rank/espatier/e8_alt,
 		/datum/mil_rank/espatier/e9,
-		/datum/mil_rank/espatier/e9_alt1,
+		/datum/mil_rank/espatier/e9_alt,
 		/datum/mil_rank/espatier/e9_alt2,
 		/datum/mil_rank/espatier/o1,
 		/datum/mil_rank/espatier/o2,
@@ -206,12 +208,11 @@
 		/datum/mil_rank/espatier/e7,
 		/datum/mil_rank/espatier/e8,
 		/datum/mil_rank/espatier/e8_alt,
-		/datum/mil_rank/espatier/e9,
+		/datum/mil_rank/espatier/e9_alt2,
 		/datum/mil_rank/espatier/o1,
 		/datum/mil_rank/espatier/o2,
 		/datum/mil_rank/espatier/o3,
 		/datum/mil_rank/espatier/o4,
-		/datum/mil_rank/espatier/o5
 	)
 
 	assistant_job = /datum/job/crew
@@ -324,91 +325,91 @@
 	name = "First Sergeant"
 	name_short = "1SG"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/e8_alt)
-	sort_order = 8
+	sort_order = 9
 
 /datum/mil_rank/espatier/e9
 	name = "Master Gunnery Sergeant"
 	name_short = "MGSG"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/e9)
-	sort_order = 9
+	sort_order = 10
 
-/datum/mil_rank/espatier/e9_alt1
+/datum/mil_rank/espatier/e9_alt
 	name = "Command Sergeant Major"
 	name_short = "CSM"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/e9_alt)
-	sort_order = 9
+	sort_order = 11
 
 /datum/mil_rank/espatier/e9_alt2
 	name = "Sergeant Major"
 	name_short = "SMA"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/e9_alt2)
-	sort_order = 9
+	sort_order = 12
 
 /datum/mil_rank/espatier/o1
 	name = "Second Lieutenant"
 	name_short = "2LT"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/officer/o1)
-	sort_order = 11
+	sort_order = 13
 
 /datum/mil_rank/espatier/o2
 	name = "First Lieutenant"
 	name_short = "1LT"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/officer/o2)
-	sort_order = 12
+	sort_order = 14
 
 /datum/mil_rank/espatier/o3
-	name = "Captain"
+	name = "Captain " //This has a space due to BYOND displaying s5 as an option when this rank is enabled. It is most likely due to the exact same name as testing revealed. This is a band-aid as I can't fix the issue at its root.
 	name_short = "CPT"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/officer/o3)
-	sort_order = 13
+	sort_order = 15
 
 /datum/mil_rank/espatier/o4
 	name = "Major"
 	name_short = "MAJ"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o4)
-	sort_order = 14
+	sort_order = 16
 
 /datum/mil_rank/espatier/o5
 	name = "Lieutenant Colonel"
 	name_short = "LTC"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o5)
-	sort_order = 15
+	sort_order = 17
 
 /datum/mil_rank/espatier/o6
 	name = "Colonel"
 	name_short = "COL"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o6)
-	sort_order = 16
+	sort_order = 18
 
 /datum/mil_rank/espatier/o7
 	name = "Brigadier General"
 	name_short = "BG"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o7)
-	sort_order = 17
+	sort_order = 19
 
 /datum/mil_rank/espatier/o8
 	name = "Major General"
 	name_short = "MG"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o8)
-	sort_order = 18
+	sort_order = 20
 
 /datum/mil_rank/espatier/o9
 	name = "Lieutenant General"
 	name_short = "LTG"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o9)
-	sort_order = 19
+	sort_order = 21
 
 /datum/mil_rank/espatier/o10
 	name = "General"
 	name_short = "GEN"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o10)
-	sort_order = 20
+	sort_order = 22
 
 /datum/mil_rank/espatier/o10_alt
 	name = "General of the Corps"
 	name_short = "GC"
 	accessory = list(/obj/item/clothing/accessory/rank/espatier/command/o10_alt)
-	sort_order = 20
+	sort_order = 23
 
 /*
  *  Surveyor Corps
@@ -439,35 +440,41 @@
 	accessory = list(/obj/item/clothing/accessory/rank/iseo/t4)
 	sort_order = 4
 
+/datum/mil_rank/sc/t5
+	name = "Chief Technician"
+	name_short = "TNC"
+	accessory = list(/obj/item/clothing/accessory/rank/iseo/t5)
+	sort_order = 5
+
 /datum/mil_rank/sc/s1
 	name = "Ensign"
 	name_short = "ENS"
 	accessory = list(/obj/item/clothing/accessory/rank/iseo/officer/s1)
-	sort_order = 5
+	sort_order = 6
 
 /datum/mil_rank/sc/s2
 	name = "Lieutenant"
 	name_short = "LT"
 	accessory = list(/obj/item/clothing/accessory/rank/iseo/officer/s2)
-	sort_order = 6
+	sort_order = 7
 
 /datum/mil_rank/sc/s3
 	name = "Lieutenant-Commander"
 	name_short = "LCDR"
 	accessory = list(/obj/item/clothing/accessory/rank/iseo/officer/s3)
-	sort_order = 7
+	sort_order = 8
 
 /datum/mil_rank/sc/s4
 	name = "Commander"
 	name_short = "CDR"
 	accessory = list(/obj/item/clothing/accessory/rank/iseo/command/s4)
-	sort_order = 8
+	sort_order = 9
 
-/datum/mil_rank/sc/s6
+/datum/mil_rank/sc/s5
 	name = "Captain"
 	name_short = "CAPT"
 	accessory = list(/obj/item/clothing/accessory/rank/iseo/command/s5)
-	sort_order = 9
+	sort_order = 10
 
 /*
  *  Civilians


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes
Standardizes ranks across the board. Check changelog.

This should help make some ranks make sense. 

FAQ:
Q: Why did all department heads get bumped down one instead of being given the option to choose from 2 ranks?
A: The CO needs to outrank the XO and the XO needs to outrank all the other department heads or the hierarchy would be awkward. We can't promote the XO and Captain therefore all department heads were demoted down to a rank that was never used.

Q: Physicians lost their leeway in choosing ranks, why?
A: They need to be outranked by the CMO and that's not possible if they could hop back and forth between O2 and O3. They also cannot be given access to O1 due to the medical resident role existing and occupying that rank.

Q: You are skipping out on the default E8 and E9 ranks and only using the alternative ones. Why?
A: The default E8/E9 ranks are used for any position that is not a command advisory position. E8s and E9s that are in a command advisory position tend to be a cut above the rest and therefore earn own snowflake ranks.

Q: Why the Chief Technician?
A: It seems a bit weird to me that you can be put in a leadership position but only have TN1 as an option. It's not weird to have an equivalent of a TN1 in a leadership position but it is equally likely to have a Chief in it too. It helps give the 3 roles mentioned a distinct rank just for them and allows it to highlight their importance a bit more.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why and what will this PR improve
Makes ranks make sense.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
GrayRachnid
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
bugfix: Patches a weird bug with O3 enabling people to select the S5 rank. They cannot join the round with the S5 rank but it was still misleading. My patch is hacky but it works and I did not observe any issues with it.
tweak: Physicians are now O2/S2
Tweak: All departments heads have been bumped down to O3/S3 to be under the XO.
Tweak: XO EC Rank bumped down from O5 to O4.
Tweak: The SEA now uses appropriate ranks for his command advisory positions. E8: First Sergeant E9: Sergeant Major.
rscadd: T5, Chief Technician, available to the Brig Chief, Senior Engineer and Deck Chief.
Tweak: Explorers have been given an addition rank as an option.
Tweak: Changed SC6 to SC5 since it seemed to be skipping a rank.
Tweak: Updated a few command job descriptions to reflect lore changes from.

/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
