### PR TITLE
Silences Spinning Emote

### DIFF
--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -337,6 +337,7 @@
 	key = "spin"
 	check_restraints = TRUE
 	emote_message_3p = "USER spins!"
+	emote_range = -1
 
 /decl/emote/visible/spin/do_extra(mob/user)
 	if(istype(user))


### PR DESCRIPTION
## Description of changes

When using `*spin` previously, it would output to chat **`[character name]`**` spins!`, which can become annoying if a user is using a BYOND macro.

## Why and what will this PR improve

Allows for undisruptive use of BYOND macros for extended emote spinning.

## Authorship

Herma / @hermaplusplus

## Changelog

:cl:
tweak: Makes spinning silent
/:cl: