### PR TITLE
Gives ec/iseo clothes minor armor and gives their jackets pockets

### DIFF
--- a/maps/torch/datums/uniforms.dm
+++ b/maps/torch/datums/uniforms.dm
@@ -45,7 +45,7 @@
 	)
 	service_under = /obj/item/clothing/under/iseo/service/uniform
 	service_skirt = /obj/item/clothing/under/iseo/service/skirt
-	service_over = /obj/item/clothing/suit/iseo/service
+	service_over = /obj/item/clothing/suit/storage/iseo/service
 	service_shoes = /obj/item/clothing/shoes/dress
 	service_hat = /obj/item/clothing/head/iseo/garrison_cap
 
@@ -69,7 +69,7 @@
 	utility_hat = /obj/item/clothing/head/espatier/utility
 	utility_extra = list(
 		/obj/item/clothing/head/espatier/beret,
-		/obj/item/clothing/suit/espatier/jacket
+		/obj/item/clothing/suit/storage/espatier/jacket
 		)
 
 	service_under = /obj/item/clothing/under/espatier/service/uniform

--- a/maps/torch/datums/uniforms_iseo.dm
+++ b/maps/torch/datums/uniforms_iseo.dm
@@ -1,56 +1,56 @@
-// 
-// ISEO Technician Outfits 
+//
+// ISEO Technician Outfits
 //
 
 /decl/hierarchy/mil_uniform/iseo/technician/engineering
 	name = "Engineering Technician"
 	utility_under = /obj/item/clothing/under/iseo/utility/engineering
-	utility_over = /obj/item/clothing/suit/iseo/utility/engineering
+	utility_over = /obj/item/clothing/suit/storage/iseo/utility/engineering
 	utility_extra = list(/obj/item/clothing/head/iseo/beret/engineering,
 						 /obj/item/clothing/gloves/duty/eng)
 
 /decl/hierarchy/mil_uniform/iseo/technician/supply
 	name = "Supply Technician"
 	utility_under = /obj/item/clothing/under/iseo/utility/supply
-	utility_over = /obj/item/clothing/suit/iseo/utility/supply
+	utility_over = /obj/item/clothing/suit/storage/iseo/utility/supply
 	utility_extra = list(/obj/item/clothing/head/iseo/beret/supply,
 						 /obj/item/clothing/gloves/duty/sup)
 
 /decl/hierarchy/mil_uniform/iseo/technician/medical
 	name = "Medical Technician"
 	utility_under = /obj/item/clothing/under/iseo/utility/medical
-	utility_over = /obj/item/clothing/suit/iseo/utility/medical
+	utility_over = /obj/item/clothing/suit/storage/iseo/utility/medical
 	utility_extra = list(/obj/item/clothing/head/iseo/beret/medical,
 						 /obj/item/clothing/gloves/duty/med)
 
 /decl/hierarchy/mil_uniform/iseo/technician/service
 	name = "Service Technician"
 	utility_under = /obj/item/clothing/under/iseo/utility/service
-	utility_over = /obj/item/clothing/suit/iseo/utility/service
+	utility_over = /obj/item/clothing/suit/storage/iseo/utility/service
 	utility_extra = list(/obj/item/clothing/head/iseo/beret/service,
 						 /obj/item/clothing/gloves/duty/srv)
 
 /decl/hierarchy/mil_uniform/iseo/technician/security
 	name = "Security Technician"
 	utility_under = /obj/item/clothing/under/iseo/utility/security
-	utility_over = /obj/item/clothing/suit/iseo/utility/security
+	utility_over = /obj/item/clothing/suit/storage/iseo/utility/security
 	utility_extra = list(/obj/item/clothing/head/iseo/beret/security,
 						 /obj/item/clothing/gloves/duty/sec,
-						 /obj/item/clothing/suit/iseo/utility/security)
+						 /obj/item/clothing/suit/storage/iseo/utility/security)
 
 /decl/hierarchy/mil_uniform/iseo/technician/exploration
 	name = "Exploration Technician"
 	utility_under = /obj/item/clothing/under/iseo/utility/exploration
-	utility_over = /obj/item/clothing/suit/iseo/utility/science
+	utility_over = /obj/item/clothing/suit/storage/iseo/utility/science
 	utility_extra = list(/obj/item/clothing/head/iseo/beret/exploration,
 						 /obj/item/clothing/gloves/duty/sci,
-						 /obj/item/clothing/suit/iseo/utility/science)
+						 /obj/item/clothing/suit/storage/iseo/utility/science)
 
 /decl/hierarchy/mil_uniform/iseo/specialist
 
 	utility_under = /obj/item/clothing/under/iseo/utility/command
 
-	service_over = /obj/item/clothing/suit/iseo/service/officer
+	service_over = /obj/item/clothing/suit/storage/iseo/service/officer
 	service_skirt = /obj/item/clothing/under/iseo/service/skirt/officer
 	service_under = /obj/item/clothing/under/iseo/service/uniform/officer
 	service_hat = /obj/item/clothing/head/iseo/wheel_cap/command
@@ -61,7 +61,7 @@
 
 /decl/hierarchy/mil_uniform/iseo/specialist/senior
 
-	service_over = /obj/item/clothing/suit/iseo/service/command
+	service_over = /obj/item/clothing/suit/storage/iseo/service/command
 	service_skirt = /obj/item/clothing/under/iseo/service/skirt/command
 	service_under = /obj/item/clothing/under/iseo/service/uniform/command
 	service_hat = /obj/item/clothing/head/iseo/wheel_cap/command

--- a/maps/torch/items/hearth_clothing/suits_espatier.dm
+++ b/maps/torch/items/hearth_clothing/suits_espatier.dm
@@ -2,32 +2,33 @@
 // Utility
 // We use attachments to customize these.
 
-/obj/item/clothing/suit/espatier/jacket
+/obj/item/clothing/suit/storage/espatier/jacket
 	name = "espatier jacket"
 	desc = "A green jacket, typically used in casual occasions. Fitted for both sexes."
 	icon = 'maps/torch/icons/converted_icons/suits/suit_service_espatiers.dmi'
+	allowed = list (/obj/item/tank/emergency,/obj/item/flashlight,/obj/item/handcuffs,/obj/item/taperecorder,/obj/item/crowbar,/obj/item/radio)
 
-/obj/item/clothing/suit/espatier/jacket/engineering
+/obj/item/clothing/suit/storage/espatier/jacket/engineering
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/jackettags/engineering)
 
-/obj/item/clothing/suit/espatier/jacket/security
+/obj/item/clothing/suit/storage/espatier/jacket/security
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/jackettags/security)
 
-/obj/item/clothing/suit/espatier/jacket/command
+/obj/item/clothing/suit/storage/espatier/jacket/command
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/jackettags/command)
 
-/obj/item/clothing/suit/espatier/jacket/supply
+/obj/item/clothing/suit/storage/espatier/jacket/supply
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/jackettags/supply)
 
-/obj/item/clothing/suit/espatier/jacket/service
+/obj/item/clothing/suit/storage/espatier/jacket/service
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/jackettags/service)
 
-/obj/item/clothing/suit/espatier/jacket/science
+/obj/item/clothing/suit/storage/espatier/jacket/science
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/jackettags/exploration)
 
 //
 // Dress
-// 
+//
 
 /obj/item/clothing/suit/espatier/dress
 	name = "dress jacket"

--- a/maps/torch/items/hearth_clothing/suits_iseo.dm
+++ b/maps/torch/items/hearth_clothing/suits_iseo.dm
@@ -1,57 +1,58 @@
-// 
+//
 // Utility
-// 
+//
 
-/obj/item/clothing/suit/iseo/utility
+/obj/item/clothing/suit/storage/iseo/utility
 	name = "utility jacket"
 	desc = "A rugged, navy blue jacket for casual wear."
 	icon = 'maps/torch/icons/converted_icons/suits/iseo_jacket.dmi'
+	allowed = list (/obj/item/tank/emergency,/obj/item/flashlight,/obj/item/handcuffs,/obj/item/taperecorder,/obj/item/crowbar,/obj/item/radio)
 
-/obj/item/clothing/suit/iseo/utility/engineering
+/obj/item/clothing/suit/storage/iseo/utility/engineering
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/engineering)
 
-/obj/item/clothing/suit/iseo/utility/security
+/obj/item/clothing/suit/storage/iseo/utility/security
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/security)
 
-/obj/item/clothing/suit/iseo/utility/medical
+/obj/item/clothing/suit/storage/iseo/utility/medical
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/medical)
 
-/obj/item/clothing/suit/iseo/utility/command
+/obj/item/clothing/suit/storage/iseo/utility/command
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/command)
 
-/obj/item/clothing/suit/iseo/utility/science
+/obj/item/clothing/suit/storage/iseo/utility/science
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/exploration)
 
-/obj/item/clothing/suit/iseo/utility/service
+/obj/item/clothing/suit/storage/iseo/utility/service
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/service)
 
-/obj/item/clothing/suit/iseo/utility/supply
+/obj/item/clothing/suit/storage/iseo/utility/supply
 	starting_accessories = list(/obj/item/clothing/accessory/department/iseo/jackettags/supply)
 
 //
 // Service
 //
 
-/obj/item/clothing/suit/iseo/service
+/obj/item/clothing/suit/storage/iseo/service
 	name = "service jacket"
 	desc = "A navy blue service jacket, typically used in semi-formal occasions. Fitted for both sexes."
 	icon = 'maps/torch/icons/converted_icons/suits/suit_service_iseo.dmi'
-
-/obj/item/clothing/suit/iseo/service/officer
+	allowed = list(/obj/item/tank/emergency,/obj/item/pen,/obj/item/taperecorder,/obj/item/radio,/obj/item/taperoll)
+/obj/item/clothing/suit/storage/iseo/service/officer
 	desc = "A navy blue service jacket, typically used in semi-formal occasions. Fitted for both sexes. This one has silver highlights."
 	icon = 'maps/torch/icons/converted_icons/suits/suit_service_officer_iseo.dmi'
 
-/obj/item/clothing/suit/iseo/service/command
+/obj/item/clothing/suit/storage/iseo/service/command
 	desc = "A navy blue service jacket, typically used in semi-formal occasions. Fitted for both sexes. This one has gold highlights."
 	icon = 'maps/torch/icons/converted_icons/suits/suit_service_command_iseo.dmi'
 
-/obj/item/clothing/suit/iseo/service/flag
+/obj/item/clothing/suit/storage/iseo/service/flag
 	desc = "A navy blue service jacket, typically used in semi-formal occasions. Fitted for both sexes. This one has red highlights."
 	icon = 'maps/torch/icons/converted_icons/suits/suit_service_flag_iseo.dmi'
 
 //
 // Dress
-// 
+//
 
 /obj/item/clothing/suit/iseo/dress
 	name = "dress jacket"

--- a/maps/torch/items/hearth_clothing/uniforms_espatier.dm
+++ b/maps/torch/items/hearth_clothing/uniforms_espatier.dm
@@ -17,6 +17,11 @@
 	name = "green utility fatigues"
 	desc = "A set of green fatigues made from sturdy, durable synthetic fibers. Mildly flash and stain resistant. Tailored for forested climates."
 	icon = 'maps/torch/icons/converted_icons/under/under_utility_green_espatiers.dmi'
+	siemens_coefficient = 0.8
+	armor = list(
+		melee = ARMOR_MELEE_MINOR,
+		energy = ARMOR_ENERGY_MINOR
+	)
 
 /obj/item/clothing/under/espatier/utility/command
 	starting_accessories = list(/obj/item/clothing/accessory/department/espatier/command)

--- a/maps/torch/items/hearth_clothing/uniforms_iseo.dm
+++ b/maps/torch/items/hearth_clothing/uniforms_iseo.dm
@@ -19,6 +19,11 @@
 	name = "utility fatigues"
 	desc = "A set of black fatigues made from sturdy, durable synthetic fibers used by the ISEO Surveyor Corps. Mildly flash and stain resistant."
 	icon = 'maps/torch/icons/converted_icons/under/under_utility_iseo.dmi'
+	siemens_coefficient = 0.8
+	armor = list(
+		melee = ARMOR_MELEE_MINOR,
+		energy = ARMOR_ENERGY_MINOR
+	)
 
 /obj/item/clothing/under/iseo/utility/command
 	desc = "A set of blue fatigues made from sturdy, durable synthetic fibers used by the ISEO Surveyor Corps. Mildly flash and stain resistant."


### PR DESCRIPTION
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->

<!-- !! PLEASE, READ THIS !! -->
<!-- If you opening a pull request which changes A LOT icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon files diff) or [MDB IGNORE] (to ignore map files diff) in PR title. -->
<!-- These tags created to prevent parsing a huge diffs and not overload IconDiffBot and MapDiffBot. -->

## Description of changes

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Gives EC and ISEO clothes basic melee/energy armor, the jackets don't get armor but they get pockets and basic suit storage now. Maz said this is ok I swear.
## Why and what will this PR improve
A lot of underclothes have some kind of armor, so it's odd for the basic clothes for the main boys to be totally paper mache- even contractor uniforms had better armor. Also like every jacket except these has pockets and stuff.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Authorship
Rock
<!-- Describe original authors of changes to credit them. -->

## Changelog

:cl:
tweak:ISEO and EC uniforms have basic armor now, the jackets have basic pockets.
/:cl:

<!-- Replace `prefix` with one of tags below. You can add more tags for multiple changelog entries.

- bugfix
- balance
- tweak
- soundadd
- sounddel
- rscadd
- rscdel
- imageadd
- imagedel
- maptweak
- spellcheck
- experiment
- admin

-->
