### PR TITLE
[TESTMERGE ONLY] Lower GC phase 2 timeout to 30 seconds

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(garbage)
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 	init_order = SS_INIT_GARBAGE
 
-	var/list/collection_timeout = list(0, 2 MINUTES, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
+	var/list/collection_timeout = list(0, 30 SECONDS, 10 SECONDS)	// deciseconds to wait before moving something up in the queue to the next level
 
 	//Stat tracking
 	var/delslasttick = 0            // number of del()'s we've done this tick


### PR DESCRIPTION
This is an early port of [NebulaSS13/Nebula#2276](https://github.com/NebulaSS13/Nebula/pull/2276). It should only be testmerged, NOT full-merged, and will hopefully be in the next weekly devmerge.