### PR TITLE
You can force move mob on catwalk in passive grab

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -79,6 +79,19 @@
 	if(!QDELETED(src) && severity != 3)
 		physically_destroyed()
 
+/obj/structure/catwalk/grab_attack(var/obj/item/grab/G)
+	var/mob/living/affecting_mob = G.get_affecting_mob()
+	if(atom_flags & ATOM_FLAG_CLIMBABLE)
+		var/obj/occupied = turf_is_crowded()
+		if (occupied)
+			to_chat(G.assailant, SPAN_WARNING("There's \a [occupied] in the way."))
+			return TRUE
+		G.affecting.forceMove(src.loc)
+		if(affecting_mob)
+			SET_STATUS_MAX(affecting_mob, STAT_WEAK, rand(2,5))
+		visible_message(SPAN_DANGER("[G.assailant] puts [G.affecting] on \the [src]."))
+		return TRUE
+
 /obj/structure/catwalk/attack_robot(var/mob/user)
 	if(Adjacent(user))
 		attack_hand(user)


### PR DESCRIPTION
## Description of changes
You can force move mob on catwalk in passive grab

## Why and what will this PR improve
Without this, you cannot move people along the catwalk in a passive grab, only in higher level grabs

## Changelog
<!-- Enter your value after first :cl: tag if you want to specify another name or several people. -->
:cl:
bugfix: You can force move mob on catwalk in passive grab
/:cl:

